### PR TITLE
fix: gcp_dmv_core NaN filter collapsing FE_DMV_ALL to 1 row (v4.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to the CryptoPrism-DB project will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.8.1] - 2026-05-13 UTC
+
+### Fixed
+- **gcp_dmv_core.py: NaN filter was collapsing FE_DMV_ALL to a single row.** The pre-existing filter `d[d['slug'].eq('bitcoin') | d.drop(columns='slug').notna().all(axis=1)]` kept only rows where every column was non-null (with a hard-coded bitcoin short-circuit). After v4.8.0 extended the JOIN to include `FE_CANDLESTICK_SIGNALS`, `FE_DOW_PATTERNS`, and `FE_PRICE_LEVELS`, any slug with a NaN in any of the 60+ joined columns -- including all slugs on the first run before `FE_DOW_PATTERNS` / `FE_PRICE_LEVELS` were populated -- got dropped. Observed effect on dbcp after the 2026-05-12 04:36 UTC cron run: `FE_DMV_ALL` had 1 row (bitcoin), `FE_DMV_SCORES` had 1 row. Replaced the filter with `dropna(subset=['slug','timestamp'])` -- defensive against pathological JOIN output but no longer drops slugs because an indicator returned NaN. The subsequent `.fillna(0)` already converts NaN signals to neutral, which is the intended downstream behavior.
+
+### Rationale
+**Why:** The bitcoin short-circuit was a smoking-gun -- the original author had hit this exact failure mode at least once and patched it for BTC only instead of fixing the rule. With 8 joined signal tables and 60+ columns, the probability of *every* column being non-null for *every* slug is low (newer coins lack history for long-period indicators like 200-day ROC). The combination of `FULL OUTER JOIN` (produces NaN for missing slug-timestamp pairs) + strict `notna().all()` filter is a guarantee of data loss whenever any upstream table lags. The fix aligns the filter with the existing `fillna(0)` semantics: missing indicator = neutral signal = 0.
+
+**How to apply:** No migration required. Pure code change. The next daily DMV cron run (2026-05-13 ~04:30 UTC) will write FE_DMV_ALL with ~1000 rows instead of 1. The cp_backtest write path (DELETE-by-timestamp + INSERT) was already correct and is unaffected.
+
+### Impact Analysis
+- Risk: Low. Removes a filter that was discarding ~99.9% of rows on dbcp. Behavioral change is "more data flows through", not "different data".
+- Downstream: FE_DMV_ALL and FE_DMV_SCORES will go from 1 row to ~1000 rows daily on dbcp. cp_backtest historical row counts unaffected (the filter ran in both paths but per-day timestamp delete-and-replace meant only the latest day was affected, and only 1 slug -- bitcoin -- survived; older days persisted from earlier runs).
+- The `.iloc[:, 4:]` bullish/bearish/neutral counter (line 86) still works because all non-id columns are signal columns and NaN-filled-to-0 counts as neutral. This is the intended semantics.
+
 ## [4.8.0] - 2026-05-11 UTC
 
 ### Added

--- a/gcp_postgres_sandbox/technical_analysis/gcp_dmv_core.py
+++ b/gcp_postgres_sandbox/technical_analysis/gcp_dmv_core.py
@@ -76,7 +76,7 @@ if df.empty:
     exit(1)
 df = (
     df.loc[:, ~df.columns.duplicated()]
-      .pipe(lambda d: d[d['slug'].eq('bitcoin') | d.drop(columns='slug').notna().all(axis=1)])
+      .dropna(subset=['slug', 'timestamp'])
       .fillna(0)
 )
 


### PR DESCRIPTION
## Summary
- Replace the brittle `bitcoin OR all-columns-non-null` filter in `gcp_dmv_core.py` with `dropna(subset=['slug','timestamp'])` so the subsequent `fillna(0)` can handle missing indicators as neutral signals.
- Bumps to **v4.8.1** in CHANGELOG.

## Why
After PR #32 (v4.8.0) added `FE_CANDLESTICK_SIGNALS`, `FE_DOW_PATTERNS`, `FE_PRICE_LEVELS` to the FULL OUTER JOIN in `gcp_dmv_core.py`, the existing strict filter `d['slug'].eq('bitcoin') | d.drop(columns='slug').notna().all(axis=1)` started discarding every non-bitcoin slug whose row had any NaN -- and on the first daily cron run after merge, `FE_DOW_PATTERNS` and `FE_PRICE_LEVELS` were still empty in `dbcp`. Result on the 2026-05-12 04:36 UTC DMV run:

| Table | Rows after run |
|---|---|
| `dbcp.FE_DMV_ALL` | **1** (bitcoin only) |
| `dbcp.FE_DMV_SCORES` | **1** |

The hard-coded `slug.eq('bitcoin')` short-circuit was a smoking-gun -- a previous run had hit the same data-loss bug and patched it for BTC alone instead of fixing the rule. With 8 joined signal tables, the probability of *every* column being non-null for *every* slug is low (young coins lack history for 200-period indicators).

## Fix
```python
df = (
    df.loc[:, ~df.columns.duplicated()]
      .dropna(subset=['slug', 'timestamp'])
      .fillna(0)
)
```

`dropna(subset=['slug','timestamp'])` defends against pathological JOIN output (slug/ts NULL from a fully-empty side); `fillna(0)` already maps missing indicator -> neutral signal, which is the intended downstream semantics for the bullish/bearish/neutral counters.

## Test plan
- [ ] Daily DMV cron at 2026-05-13 ~04:30 UTC completes successfully on the new SHA
- [ ] `SELECT count(*) FROM "FE_DMV_ALL"` on dbcp post-run returns ~1000 (not 1)
- [ ] `SELECT count(*) FROM "FE_DMV_SCORES"` on dbcp post-run returns ~1000
- [ ] cp_backtest `FE_DMV_ALL` shows a fresh 2026-05-12 timestamp row count appended (not just bitcoin)
- [ ] No new tables empty: `FE_DOW_PATTERNS` and `FE_PRICE_LEVELS` populate (~1000 rows each) since their scripts now run before core

## Out of scope
- `dbcp.FE_TVV_SIGNALS` is currently empty (0 rows) -- separate issue, not caused by this code path. Tomorrow's `gcp_dmv_tvv.py` cron step will TRUNCATE+INSERT and refill it.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)