### PR TITLE
perf: batched INSERTs across all DMV scripts (v4.8.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to the CryptoPrism-DB project will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.8.2] - 2026-05-13 UTC
+
+### Changed
+- **Batched INSERTs on every DMV pipeline write.** Added `method="multi", chunksize=200` to all `to_sql()` calls across the 10 production technical-analysis scripts:
+  - `gcp_dmv_met.py` (4 calls: FE_METRICS + FE_METRICS_SIGNAL to dbcp and cp_backtest)
+  - `gcp_dmv_tvv.py`, `gcp_dmv_mom.py`, `gcp_dmv_osc.py`, `gcp_dmv_pct.py`, `gcp_dmv_rat.py`, `gcp_dmv_candle.py`, `gcp_dmv_dow.py`, `gcp_dmv_levels.py` (2 calls each: dbcp + cp_backtest)
+  - `gcp_dmv_core.py` (2 calls: FE_DMV_ALL to dbcp + cp_backtest; FE_DMV_SCORES already had batching from an earlier change)
+
+### Rationale
+**Why:** Default `to_sql()` issues one INSERT per row. With 1000 rows over a high-latency link (Cloud Run / GitHub Actions / local Windows -> Cloud SQL postgres), each write to a signal table costs minutes in network round-trips. The 2026-05-13 manual `gcp_dmv_tvv.py` refill of `dbcp.FE_TVV_SIGNALS` was killed mid-INSERT after 20+ minutes; a second run with `method="multi", chunksize=200` finished the full pipeline (data fetch + indicator compute + 4 table writes including cp_backtest) in **3.64 minutes** -- ~4x end-to-end speedup, ~10x on the write step alone.
+
+**How to apply:** No migration. No DDL change. The pg8000 driver enforces a 16-bit BIND parameter cap (65535); with chunksize=200 the largest table (FE_DMV_ALL, 61 cols) packs 12,200 params per INSERT -- well under the cap. Smaller signal tables (10-12 cols) pack 2,000-2,400 per INSERT.
+
+### Impact Analysis
+- Risk: Low. Behavioral semantics unchanged -- still TRUNCATE+INSERT (or DELETE-by-timestamp+INSERT for cp_backtest); only the INSERT batching strategy changed. No row-count or column-value differences.
+- Expected daily DMV workflow runtime reduction: 5-10 minutes total.
+- Validated: `gcp_dmv_tvv.py` end-to-end against dbcp + cp_backtest on 2026-05-13, 3.64 min total runtime, both tables refilled with 1000 / 1,127,277 rows respectively. Other scripts share the identical write pattern -- same fix mechanism.
+- Parallel work in PR #33 (v4.8.1) fixes the unrelated NaN filter in `gcp_dmv_core.py:79`. Order-independent.
+- The `backups/` directory was intentionally not touched.
+
 ## [4.8.0] - 2026-05-11 UTC
 
 ### Added

--- a/gcp_postgres_sandbox/technical_analysis/gcp_dmv_candle.py
+++ b/gcp_postgres_sandbox/technical_analysis/gcp_dmv_candle.py
@@ -324,7 +324,7 @@ def push_to_db(df, table_name, engine):
     with engine.connect() as conn:
         conn.execute(text(f'TRUNCATE TABLE "{table_name}"'))
         conn.commit()
-    df.to_sql(table_name, con=engine, if_exists="append", index=False)
+    df.to_sql(table_name, con=engine, if_exists="append", index=False, method="multi", chunksize=200)
     logger.info(f"{table_name} (dbcp) uploaded.")
 
 
@@ -338,7 +338,7 @@ def push_to_db_backtest(df, table_name, engine):
                     {"ts": ts},
                 )
             conn.commit()
-    df.to_sql(table_name, con=engine, if_exists="append", index=False)
+    df.to_sql(table_name, con=engine, if_exists="append", index=False, method="multi", chunksize=200)
     logger.info(f"{table_name} (cp_backtest) appended.")
 
 

--- a/gcp_postgres_sandbox/technical_analysis/gcp_dmv_core.py
+++ b/gcp_postgres_sandbox/technical_analysis/gcp_dmv_core.py
@@ -92,7 +92,7 @@ for index, row in df.iloc[:, 4:].iterrows():
 with gcp_engine.connect() as conn:
     conn.execute(text('TRUNCATE TABLE "FE_DMV_ALL"'))
     conn.commit()
-df.to_sql('FE_DMV_ALL', con=gcp_engine, if_exists='append', index=False)
+df.to_sql('FE_DMV_ALL', con=gcp_engine, if_exists='append', index=False, method='multi', chunksize=200)
 logger.info("FE_DMV_ALL uploaded.")
 
 Durability = df[['slug'] + [c for c in df.columns if c.startswith('d_')]]
@@ -137,7 +137,7 @@ try:
                 conn.execute(text('DELETE FROM "FE_DMV_ALL" WHERE "timestamp" = :ts'), {"ts": ts})
                 conn.execute(text('DELETE FROM "FE_DMV_SCORES" WHERE "timestamp" = :ts'), {"ts": ts})
                 conn.commit()
-    df.to_sql('FE_DMV_ALL', con=gcp_engine_bt, if_exists='append', index=False)
+    df.to_sql('FE_DMV_ALL', con=gcp_engine_bt, if_exists='append', index=False, method='multi', chunksize=200)
     logger.info("FE_DMV_ALL appended to cp_backtest.")
     dmv_scores.to_sql('FE_DMV_SCORES', con=gcp_engine_bt, if_exists='append', index=False, method='multi', chunksize=BATCH_SIZE)
     logger.info("FE_DMV_SCORES appended to cp_backtest.")

--- a/gcp_postgres_sandbox/technical_analysis/gcp_dmv_dow.py
+++ b/gcp_postgres_sandbox/technical_analysis/gcp_dmv_dow.py
@@ -212,7 +212,7 @@ def push_to_db(df, table_name, engine):
     with engine.connect() as conn:
         conn.execute(text(f'TRUNCATE TABLE "{table_name}"'))
         conn.commit()
-    df.to_sql(table_name, con=engine, if_exists="append", index=False)
+    df.to_sql(table_name, con=engine, if_exists="append", index=False, method="multi", chunksize=200)
     logger.info(f"{table_name} (dbcp) uploaded.")
 
 
@@ -226,7 +226,7 @@ def push_to_db_backtest(df, table_name, engine):
                     {"ts": ts},
                 )
             conn.commit()
-    df.to_sql(table_name, con=engine, if_exists="append", index=False)
+    df.to_sql(table_name, con=engine, if_exists="append", index=False, method="multi", chunksize=200)
     logger.info(f"{table_name} (cp_backtest) appended.")
 
 

--- a/gcp_postgres_sandbox/technical_analysis/gcp_dmv_levels.py
+++ b/gcp_postgres_sandbox/technical_analysis/gcp_dmv_levels.py
@@ -187,7 +187,7 @@ def push_to_db(df, table_name, engine):
     with engine.connect() as conn:
         conn.execute(text(f'TRUNCATE TABLE "{table_name}"'))
         conn.commit()
-    df.to_sql(table_name, con=engine, if_exists="append", index=False)
+    df.to_sql(table_name, con=engine, if_exists="append", index=False, method="multi", chunksize=200)
     logger.info(f"{table_name} (dbcp) uploaded.")
 
 
@@ -201,7 +201,7 @@ def push_to_db_backtest(df, table_name, engine):
                     {"ts": ts},
                 )
             conn.commit()
-    df.to_sql(table_name, con=engine, if_exists="append", index=False)
+    df.to_sql(table_name, con=engine, if_exists="append", index=False, method="multi", chunksize=200)
     logger.info(f"{table_name} (cp_backtest) appended.")
 
 

--- a/gcp_postgres_sandbox/technical_analysis/gcp_dmv_met.py
+++ b/gcp_postgres_sandbox/technical_analysis/gcp_dmv_met.py
@@ -219,7 +219,7 @@ from sqlalchemy import create_engine, text
 gcp_engine = create_engine(f'postgresql+pg8000://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}', pool_pre_ping=True)
 
 # Replace FE_METRICS in dbcp (drop+create to keep schema in sync)
-metrics.to_sql('FE_METRICS', con=gcp_engine, if_exists='replace', index=False)
+metrics.to_sql('FE_METRICS', con=gcp_engine, if_exists='replace', index=False, method='multi', chunksize=200)
 
 print("Metrics DataFrame uploaded to dbcp database successfully!")
 
@@ -232,7 +232,7 @@ if 'timestamp' in metrics.columns:
         with gcp_engine_bt.connect() as conn:
             conn.execute(text('DELETE FROM "FE_METRICS" WHERE "timestamp" = :ts'), {"ts": ts})
             conn.commit()
-metrics.to_sql('FE_METRICS', con=gcp_engine_bt, if_exists='append', index=False)
+metrics.to_sql('FE_METRICS', con=gcp_engine_bt, if_exists='append', index=False, method='multi', chunksize=200)
 
 print("Metrics DataFrame uploaded to cp_backtest database successfully!")
 
@@ -289,7 +289,7 @@ from sqlalchemy import create_engine
 with gcp_engine.connect() as conn:
     conn.execute(text('TRUNCATE TABLE "FE_METRICS_SIGNAL"'))
     conn.commit()
-metrics_signal.to_sql('FE_METRICS_SIGNAL', con=gcp_engine, if_exists='append', index=False)
+metrics_signal.to_sql('FE_METRICS_SIGNAL', con=gcp_engine, if_exists='append', index=False, method='multi', chunksize=200)
 
 print("FE_METRICS_SIGNAL DataFrame uploaded to dbcp database successfully!")
 
@@ -302,7 +302,7 @@ if 'timestamp' in metrics_signal.columns:
         with gcp_engine_bt.connect() as conn:
             conn.execute(text('DELETE FROM "FE_METRICS_SIGNAL" WHERE "timestamp" = :ts'), {"ts": ts})
             conn.commit()
-metrics_signal.to_sql('FE_METRICS_SIGNAL', con=gcp_engine_bt, if_exists='append', index=False)
+metrics_signal.to_sql('FE_METRICS_SIGNAL', con=gcp_engine_bt, if_exists='append', index=False, method='multi', chunksize=200)
 
 end_time = time.time()
 elapsed_time_seconds = end_time - start_time

--- a/gcp_postgres_sandbox/technical_analysis/gcp_dmv_mom.py
+++ b/gcp_postgres_sandbox/technical_analysis/gcp_dmv_mom.py
@@ -193,7 +193,7 @@ def push_to_db(df, table_name, engine, if_exists="replace"):
             with engine.connect() as conn:
                 conn.execute(text(f'TRUNCATE TABLE "{table_name}"'))
                 conn.commit()
-            df.to_sql(table_name, con=engine, if_exists="append", index=False)
+            df.to_sql(table_name, con=engine, if_exists="append", index=False, method="multi", chunksize=200)
         else:
             # Backtest DB: DELETE matching timestamps first to prevent duplicates
             if 'timestamp' in df.columns:
@@ -205,7 +205,7 @@ def push_to_db(df, table_name, engine, if_exists="replace"):
                             {"ts": ts}
                         )
                     conn.commit()
-            df.to_sql(table_name, con=engine, if_exists="append", index=False)
+            df.to_sql(table_name, con=engine, if_exists="append", index=False, method="multi", chunksize=200)
         logging.info(f"{table_name} uploaded successfully!")
     except Exception as e:
         logging.error(f"Error pushing data to {table_name}: {e}")

--- a/gcp_postgres_sandbox/technical_analysis/gcp_dmv_osc.py
+++ b/gcp_postgres_sandbox/technical_analysis/gcp_dmv_osc.py
@@ -356,7 +356,7 @@ def push_to_db(df, table_name, engine, if_exists="replace"):
             with engine.connect() as conn:
                 conn.execute(text(f'TRUNCATE TABLE "{table_name}"'))
                 conn.commit()
-            df.to_sql(table_name, con=engine, if_exists="append", index=False)
+            df.to_sql(table_name, con=engine, if_exists="append", index=False, method="multi", chunksize=200)
         else:
             # Backtest DB: DELETE matching timestamps first to prevent duplicates
             if 'timestamp' in df.columns:
@@ -368,7 +368,7 @@ def push_to_db(df, table_name, engine, if_exists="replace"):
                             {"ts": ts}
                         )
                     conn.commit()
-            df.to_sql(table_name, con=engine, if_exists="append", index=False)
+            df.to_sql(table_name, con=engine, if_exists="append", index=False, method="multi", chunksize=200)
         logging.info(f"{table_name} uploaded successfully!")
     except Exception as e:
         logging.error(f"Error pushing data to {table_name}: {e}")

--- a/gcp_postgres_sandbox/technical_analysis/gcp_dmv_pct.py
+++ b/gcp_postgres_sandbox/technical_analysis/gcp_dmv_pct.py
@@ -148,7 +148,7 @@ def push_to_db(df, table_name):
     with engine.connect() as conn:
         conn.execute(text(f'TRUNCATE TABLE "{table_name}"'))
         conn.commit()
-    df.to_sql(table_name, con=engine, if_exists="append", index=False)
+    df.to_sql(table_name, con=engine, if_exists="append", index=False, method="multi", chunksize=200)
     engine.dispose()
     logging.info(f"✅ {table_name} uploaded successfully to LIVE DB!")
 
@@ -164,7 +164,7 @@ def push_to_db_backtest(df, table_name):
                     {"ts": ts}
                 )
             conn.commit()
-    df.to_sql(table_name, con=engine, if_exists="append", index=False)
+    df.to_sql(table_name, con=engine, if_exists="append", index=False, method="multi", chunksize=200)
     engine.dispose()
     logging.info(f"{table_name} uploaded to backtest successfully!")
 

--- a/gcp_postgres_sandbox/technical_analysis/gcp_dmv_rat.py
+++ b/gcp_postgres_sandbox/technical_analysis/gcp_dmv_rat.py
@@ -239,7 +239,7 @@ def push_to_db(df, table_name, engine, if_exists="replace"):
             with engine.connect() as conn:
                 conn.execute(text(f'TRUNCATE TABLE "{table_name}"'))
                 conn.commit()
-            df.to_sql(table_name, con=engine, if_exists="append", index=False)
+            df.to_sql(table_name, con=engine, if_exists="append", index=False, method="multi", chunksize=200)
         else:
             # Backtest DB: DELETE matching timestamps first to prevent duplicates
             if 'timestamp' in df.columns:
@@ -251,7 +251,7 @@ def push_to_db(df, table_name, engine, if_exists="replace"):
                             {"ts": ts}
                         )
                     conn.commit()
-            df.to_sql(table_name, con=engine, if_exists="append", index=False)
+            df.to_sql(table_name, con=engine, if_exists="append", index=False, method="multi", chunksize=200)
         logging.info(f"{table_name} uploaded successfully!")
     except Exception as e:
         logging.error(f"Error pushing data to {table_name}: {e}")

--- a/gcp_postgres_sandbox/technical_analysis/gcp_dmv_tvv.py
+++ b/gcp_postgres_sandbox/technical_analysis/gcp_dmv_tvv.py
@@ -260,7 +260,8 @@ def push_to_db(df, table_name):
     with engine.connect() as conn:
         conn.execute(text(f'TRUNCATE TABLE "{table_name}"'))
         conn.commit()
-    df.to_sql(table_name, con=engine, if_exists="append", index=False)
+    df.to_sql(table_name, con=engine, if_exists="append", index=False,
+              method="multi", chunksize=200)
     engine.dispose()
     logging.info(f"✅ {table_name} uploaded successfully!")
 
@@ -280,7 +281,8 @@ def push_to_db_backtest(df, table_name):
                     {"ts": ts}
                 )
             conn.commit()
-    df.to_sql(table_name, con=engine, if_exists="append", index=False)
+    df.to_sql(table_name, con=engine, if_exists="append", index=False,
+              method="multi", chunksize=200)
     engine.dispose()
     logging.info(f"{table_name} uploaded to backtest successfully!")
 


### PR DESCRIPTION
## Summary
Add `method=\"multi\", chunksize=200` to every production `to_sql()` call in the DMV pipeline. Cuts per-table write time ~10x by batching INSERTs into a single multi-row statement per chunk instead of one statement per row.

## Why
Default `pandas.DataFrame.to_sql()` issues one INSERT per row. With 1000 rows × ~200 ms RTT to Cloud SQL postgres (over both GitHub Actions and local Windows links), every signal-table write costs minutes in pure network round-trips.

**Concrete measurement** (this session):
- 2026-05-13 manual `gcp_dmv_tvv.py` refill of `dbcp.FE_TVV_SIGNALS`: killed mid-INSERT after 20+ minutes (the prior pre-batched version had reached the first dbcp INSERT and not made it through 1000 rows).
- Re-run with batched inserts: **3.64 min total** (data fetch + indicator compute + 4 writes including cp_backtest). End-to-end ~4x speedup, write-step alone ~10x.

The previously-batched calls in `gcp_dmv_core.py` (FE_DMV_SCORES) already use this pattern -- this PR brings the rest of the pipeline into line.

## Scope
| File | to_sql calls patched |
|---|---|
| `gcp_dmv_met.py` | 4 (FE_METRICS + FE_METRICS_SIGNAL, dbcp + cp_backtest) |
| `gcp_dmv_tvv.py` | 2 |
| `gcp_dmv_mom.py` | 2 |
| `gcp_dmv_osc.py` | 2 |
| `gcp_dmv_pct.py` | 2 |
| `gcp_dmv_rat.py` | 2 |
| `gcp_dmv_candle.py` | 2 |
| `gcp_dmv_dow.py` | 2 |
| `gcp_dmv_levels.py` | 2 |
| `gcp_dmv_core.py` | 2 (FE_DMV_ALL, dbcp + cp_backtest; FE_DMV_SCORES was already batched) |
| **Total** | **22** |

`backups/` deliberately not touched.

## Safety
- pg8000 enforces a 16-bit BIND parameter cap (65535).
- Largest table is `FE_DMV_ALL` (61 cols). chunksize=200 -> 12,200 params per INSERT, well under cap.
- Smaller signal tables: 10-12 cols × 200 = 2,000-2,400 params per INSERT.
- No DDL change. No schema change. No row-count or column-value semantics change.

## Test plan
- [ ] Daily DMV cron at 2026-05-13 ~04:30 UTC completes on the new SHA
- [ ] DMV workflow runtime drops 5-10 min vs the pre-merge baseline
- [ ] All FE_* signal tables and FE_DMV_ALL repopulate with expected row counts
- [ ] cp_backtest historical row counts preserved (only the current-day timestamp's rows refresh)

## Relation to PR #33 (v4.8.1)
PR #33 fixes the unrelated NaN filter in `gcp_dmv_core.py:79`. Both branches are off `main`. Order-independent at merge time (different lines). May produce a one-line CHANGELOG merge conflict that resolves trivially.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)