### PR TITLE
fix: gcp_dmv_core.py schema filter for FE_DMV_ALL (v4.8.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to the CryptoPrism-DB project will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.8.3] - 2026-05-13 UTC
+
+### Fixed
+- **gcp_dmv_core.py: INSERT to FE_DMV_ALL failed silently with "in failed transaction block" because the JOIN's `SELECT *` pulled 12 value columns that FE_DMV_ALL's schema does not have.** v4.8.0 added `FE_DOW_PATTERNS` and `FE_PRICE_LEVELS` to the FULL OUTER JOIN. Those upstream tables carry value columns (`m_dow_support`, `m_dow_resistance`, `fib_swing_low`, `fib_swing_high`, `fib_0_236`, `fib_0_382`, `fib_0_500`, `fib_0_618`, `fib_0_786`, `atr_band_mid`, `atr_band_upper`, `atr_band_lower`) alongside their bin signal columns. The Phase 4/5 migrations intentionally added only the bin columns to FE_DMV_ALL (signal-only design), but `SELECT *` flows everything through. pg8000 swallowed the original Postgres error and only surfaced "in failed transaction block" on commit, making the failure mode invisible until probed.
+- Added a dynamic schema filter that reads `information_schema.columns` for FE_DMV_ALL and trims the DataFrame to only those columns before the TRUNCATE+INSERT. Robust to future upstream column additions.
+
+### Rationale
+**Why:** This was the second layer of bugs on top of v4.8.1. After v4.8.1 fixed the NaN-filter that was collapsing FE_DMV_ALL to 1 row, the manual `gcp_dmv_core.py` re-run still failed -- the underlying mismatch had been masked by the 1-row filter (yesterday's run wrote bitcoin only, so the column-mismatch only became fatal once 1000+ rows were being inserted). pg8000's "in failed transaction block" error message is genuinely unhelpful here; a probe script that attempts a single-row insert was needed to surface the real cause.
+
+**How to apply:** Pure code change. No DDL. The script now self-discovers which columns FE_DMV_ALL actually has and inserts only those.
+
+### Impact Analysis
+- Risk: Low. Behavioral change: previously the script raised on second-row INSERT in any environment where dow/levels signal tables were populated and `SELECT *` pulled their value columns through. Now those value columns are dropped before INSERT.
+- Validated: manual `gcp_dmv_core.py` run on 2026-05-13 against dbcp + cp_backtest, 2.07 min runtime. `FE_DMV_ALL` and `FE_DMV_SCORES` both populated with 2000 rows on dbcp (1013 distinct slugs across the JOIN's timestamp window). Score distribution: avg Durability=21.59, Momentum=3.43, Valuation=25.63; Momentum range -36.84 to +36.84.
+- Future-proof: the value cols `m_dow_support` and `m_dow_resistance` are prefixed `m_dow_` and would have been picked up by `Momentum.startswith('m_')` and polluted the Momentum_Score with raw price values (50,000+) instead of clean -1/0/+1 bins. The schema filter removes them before score calc as a side effect.
+
 ## [4.8.2] - 2026-05-13 UTC
 
 ### Changed

--- a/gcp_postgres_sandbox/technical_analysis/gcp_dmv_core.py
+++ b/gcp_postgres_sandbox/technical_analysis/gcp_dmv_core.py
@@ -88,6 +88,16 @@ for index, row in df.iloc[:, 4:].iterrows():
     df.at[index, 'bearish'] = (row == -1).sum()
     df.at[index, 'neutral'] = (row == 0).sum()
 
+# Filter df to columns present in FE_DMV_ALL. Upstream signal tables
+# (FE_DOW_PATTERNS, FE_PRICE_LEVELS) carry value columns alongside bins; the
+# JOIN's SELECT * pulls them through but FE_DMV_ALL is intentionally bin-only.
+with gcp_engine.connect() as conn:
+    fe_dmv_all_cols = {r[0] for r in conn.execute(text(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_name='FE_DMV_ALL'"
+    )).fetchall()}
+df = df[[c for c in df.columns if c in fe_dmv_all_cols]]
+
 # TRUNCATE and INSERT for FE_DMV_ALL
 with gcp_engine.connect() as conn:
     conn.execute(text('TRUNCATE TABLE "FE_DMV_ALL"'))


### PR DESCRIPTION
## Summary
The JOIN's `SELECT *` was pulling 12 value columns from `FE_DOW_PATTERNS` and `FE_PRICE_LEVELS` that don't exist in `FE_DMV_ALL`'s schema. INSERT failed; pg8000 hid the real error behind \"in failed transaction block\". Fix: trim the DataFrame to FE_DMV_ALL's actual columns before the INSERT, using `information_schema.columns`.

## Why this wasn't caught by PR #33 (v4.8.1)
v4.8.1 fixed the NaN filter that was collapsing FE_DMV_ALL to 1 row (bitcoin only). With only bitcoin flowing through, the column-mismatch INSERT either silently succeeded for 1 row or never produced visible breakage. As soon as the v4.8.1 fix let ~1000 rows reach the INSERT, the column-mismatch surfaced. Two layered bugs from the same v4.8.0 PR.

## The 12 phantom columns
| Source table | Columns |
|---|---|
| `FE_DOW_PATTERNS` | `m_dow_support`, `m_dow_resistance` |
| `FE_PRICE_LEVELS` | `fib_swing_low`, `fib_swing_high`, `fib_0_236`, `fib_0_382`, `fib_0_500`, `fib_0_618`, `fib_0_786`, `atr_band_mid`, `atr_band_upper`, `atr_band_lower` |

All value columns. The Phase 4/5 migrations intentionally added only the **bin** columns to `FE_DMV_ALL` (the score aggregation table is signal-only). The JOIN pulls everything; nothing filtered before the INSERT.

## Bonus correctness fix
`m_dow_support` and `m_dow_resistance` start with `m_dow_` -> they would have been swept into `Momentum.startswith('m_')` and polluted `Momentum_Score` with raw price levels (50,000+) instead of clean -1/0/+1 bins. The schema filter removes them before the score calc, fixing this as a side effect.

## Validation
- Manual `python gcp_postgres_sandbox/technical_analysis/gcp_dmv_core.py` on 2026-05-13: 2.07 min, exit 0
- `dbcp.FE_DMV_ALL`: 2000 rows / 1013 distinct slugs
- `dbcp.FE_DMV_SCORES`: 2000 rows
- `cp_backtest.FE_DMV_ALL`: 34,370 rows (was 34,348, +22 delta for the date refresh)
- Score distribution: avg D=21.59 M=3.43 V=25.63; M range -36.84 to +36.84 (no scale pollution from raw price values)

## Test plan
- [ ] Tonight's 04:30 UTC DMV cron completes successfully on the new SHA
- [ ] `FE_DMV_ALL` row count stays in the ~1000-2000 range, not 1
- [ ] Score distributions stay in the [-100, 100] range -- no momentum scores in the thousands

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)