### PR TITLE
fix: pd.NA id column dtype in dow/levels/candle (v4.8.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to the CryptoPrism-DB project will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.8.4] - 2026-05-13 UTC
+
+### Fixed
+- **gcp_dmv_dow.py / gcp_dmv_levels.py / gcp_dmv_candle.py: `out["id"] = pd.NA` was producing an `object` dtype column of Python `None` values that pg8000 could not bind for a `bigint` destination column.** The INSERT failed; pg8000 again hid the underlying error behind "in failed transaction block". Replaced with `out["id"] = pd.array([pd.NA] * len(out), dtype="Int64")` so the column is a proper pandas nullable Int64.
+
+### Rationale
+**Why:** All three new v4.8.0 scripts assign a placeholder `id` because the destination FE_* tables expect an `id` column (carried through from OHLCV-derived feature tables), but the scripts compute one-row-per-slug aggregates and don't have a meaningful id to write. The intent was "leave id as NULL". The original `out["id"] = pd.NA` looks correct at first glance, but on a new column with no prior dtype, pandas falls back to `object` and fills with Python `None` objects -- which pg8000 refuses to bind for a numeric column.
+
+The candle script had this same line but inside `if "id" not in latest.columns`, which never fires because the upstream OHLCV table always has `id` -- the bug was latent there. Dow and levels assign unconditionally, so they failed every run. The bug was masked until today because the new scripts had never executed end-to-end (PR #32 merged after the daily cron, and the local validation step skipped them).
+
+**How to apply:** Pure code change. Three one-line edits. No DDL.
+
+### Impact Analysis
+- Risk: Low. Behavioral change: previously the INSERT to FE_DOW_PATTERNS / FE_PRICE_LEVELS raised an error and the script aborted. Now it succeeds, writing rows with `id=NULL` (matching the existing schema's nullability).
+- Validated: full chain `gcp_dmv_dow.py -> gcp_dmv_levels.py -> gcp_dmv_core.py` on 2026-05-13 against dbcp + cp_backtest. Runtime 5.06 min total. All four downstream tables now hold 1000 rows at timestamp 2026-05-12 (previously 0 for dow/levels, 2000 stale-day rows for FE_DMV_ALL).
+- pg8000's "in failed transaction block" error message remains a frustration -- it surfaces only at commit time and offers no detail on the actual bind failure. Diagnostic required a probe script that attempted a 5-row insert with dtype variants (Object vs Int64 with NA vs drop column).
+
 ## [4.8.3] - 2026-05-13 UTC
 
 ### Fixed

--- a/gcp_postgres_sandbox/technical_analysis/gcp_dmv_candle.py
+++ b/gcp_postgres_sandbox/technical_analysis/gcp_dmv_candle.py
@@ -355,7 +355,7 @@ if __name__ == "__main__":
 
     # id column may not exist in source OHLCV; ensure it as nullable so to_sql does not fail
     if "id" not in latest.columns:
-        latest["id"] = pd.NA
+        latest["id"] = pd.array([pd.NA] * len(latest), dtype="Int64")
 
     out = latest[REQUIRED_COLUMNS].copy()
 

--- a/gcp_postgres_sandbox/technical_analysis/gcp_dmv_dow.py
+++ b/gcp_postgres_sandbox/technical_analysis/gcp_dmv_dow.py
@@ -244,7 +244,7 @@ if __name__ == "__main__":
     for c in BIN_COLS:
         out[c] = out[c].astype("Int64")
 
-    out["id"] = pd.NA
+    out["id"] = pd.array([pd.NA] * len(out), dtype="Int64")
     out = out[["id", "slug", "timestamp"] + VALUE_COLS + BIN_COLS]
 
     push_to_db(out, "FE_DOW_PATTERNS", engine)

--- a/gcp_postgres_sandbox/technical_analysis/gcp_dmv_levels.py
+++ b/gcp_postgres_sandbox/technical_analysis/gcp_dmv_levels.py
@@ -219,7 +219,7 @@ if __name__ == "__main__":
     for c in BIN_COLS:
         out[c] = out[c].astype("Int64")
 
-    out["id"] = pd.NA
+    out["id"] = pd.array([pd.NA] * len(out), dtype="Int64")
     out = out[["id", "slug", "timestamp"] + VALUE_COLS + BIN_COLS]
 
     push_to_db(out, "FE_PRICE_LEVELS", engine)


### PR DESCRIPTION
## Summary
`out[\"id\"] = pd.NA` produces an `object`-dtype column of Python `None` values. pg8000 refused to bind those for a `bigint` destination, failing the INSERT with the unhelpful \"in failed transaction block\" error at commit time. Fix: use `pd.array([pd.NA] * len(out), dtype=\"Int64\")` — a proper pandas nullable Int64 that pg8000 can serialize, same intent (id stays NULL in postgres).

## Why this slipped through
All three new v4.8.0 scripts (candle, dow, levels) had never executed end-to-end anywhere:
- PR #32 merged on 2026-05-12 08:38 UTC, **after** that day's 04:30 UTC DMV cron
- Today's local validation was the first real run
- Candle's `out[\"id\"] = pd.NA` is conditional on `id` not being in upstream OHLCV (which it always is), so candle never tripped the bug — but the latent code is identical and fixed here for consistency

## Diagnostic
pg8000 keeps surfacing only the secondary \"in failed transaction block\" error, not the underlying bind failure. A probe script that attempted three insert variants (object/None, Int64/NA, drop column) was needed to confirm dtype was the cause.

| Variant | Result |
|---|---|
| Drop `id` column entirely | ✓ succeeds |
| `id` = pd.NA (object dtype, None values) | ✗ fails |
| `id` = pd.array([pd.NA]*n, dtype=\"Int64\") | ✓ succeeds |

## Validation
End-to-end chain run on 2026-05-13:

| Script | Runtime | Status |
|---|---|---|
| `gcp_dmv_dow.py` | 1.59 min | OK — FE_DOW_PATTERNS: 1000 rows |
| `gcp_dmv_levels.py` | 1.93 min | OK — FE_PRICE_LEVELS: 1000 rows |
| `gcp_dmv_core.py` | 1.54 min | OK — FE_DMV_ALL/SCORES: 1000 rows each |

All four downstream tables now hold 1000 rows at timestamp 2026-05-12.

## Test plan
- [ ] Tonight's 04:30 UTC DMV cron completes successfully on the new SHA, end-to-end including candle/dow/levels/core
- [ ] FE_DOW_PATTERNS and FE_PRICE_LEVELS populate (~1000 rows each) on dbcp
- [ ] FE_DMV_ALL signals are now driven by real dow/levels values, not NaN-fill-0 neutrals

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)