### PR TITLE
docs: knowledge_base for v4.7.0-v4.8.4 indicator expansion

### DIFF
--- a/knowledge_base/gcp_dmv_candle.md
+++ b/knowledge_base/gcp_dmv_candle.md
@@ -1,0 +1,108 @@
+# gcp_dmv_candle.py - Candlestick Pattern Detection Engine
+
+## Overview
+This script implements **9 directional candlestick pattern detectors** from Zerodha Varsity Module 2 as plain vectorised pandas/numpy. Added in v4.8.0 (Phase 2 of the DMV indicator expansion). Outputs go to `FE_CANDLESTICK_SIGNALS` and feed into `FE_DMV_ALL` via the FULL OUTER JOIN in `gcp_dmv_core.py`.
+
+Non-directional patterns (Doji, Spinning Top) are intentionally skipped — they convey indecision rather than direction and would distort DMV bullish/bearish counts if encoded as +/-1.
+
+## The Nine Patterns
+
+Each detector writes a single column `m_cnd_<name>_bin` taking values in `{-1, 0, +1}`:
+
+| Pattern | Bin Column | Direction | Logic |
+|---|---|---|---|
+| Marubozu | `m_cnd_marubozu_bin` | +1 / -1 | Body fills >=95% of range; tiny shadows |
+| Hammer | `m_cnd_hammer_bin` | +1 | Paper umbrella after downtrend (long lower shadow, small body up top) |
+| Hanging Man | `m_cnd_hanging_man_bin` | -1 | Paper umbrella after uptrend (same geometry, bearish context) |
+| Shooting Star | `m_cnd_shooting_star_bin` | -1 | Inverted paper umbrella after uptrend (long upper shadow) |
+| Engulfing | `m_cnd_engulfing_bin` | +1 / -1 | Current body fully engulfs prior body with opposite direction |
+| Harami | `m_cnd_harami_bin` | +1 / -1 | Inside bar opposite-coloured to prior body (mother-with-baby) |
+| Piercing | `m_cnd_piercing_bin` | +1 | Bullish reversal: red bar then blue bar closing above prior midpoint |
+| Dark Cloud Cover | `m_cnd_dark_cloud_bin` | -1 | Bearish reversal: blue bar then red bar closing below prior midpoint |
+| Star | `m_cnd_star_bin` | +1 / -1 | Three-bar morning star (+1) / evening star (-1) |
+
+## Detailed Functionality
+
+### Prior-trend gate
+Several patterns (Hammer, Hanging Man, Shooting Star, Piercing, Dark Cloud, Star) only register inside an existing trend. Trend proxy is fast and cheap:
+```python
+def add_prior_trend_flags(df):
+    prev_close   = df.groupby("slug")["close"].shift(1)
+    close_5_back = df.groupby("slug")["close"].shift(5)
+    df["_prior_up"]   = (prev_close > close_5_back)
+    df["_prior_down"] = (prev_close < close_5_back)
+```
+Requires >=5 prior bars per slug; NaN otherwise.
+
+### Per-bar geometry helpers
+```python
+def add_geometry(df):
+    df["_body"]  = (df["close"] - df["open"]).abs()
+    df["_us"]    = df["high"] - df[["open", "close"]].max(axis=1)   # upper shadow
+    df["_ls"]    = df[["open", "close"]].min(axis=1) - df["low"]    # lower shadow
+    df["_rng"]   = df["high"] - df["low"]
+    df["_red"]   = df["close"] < df["open"]
+    df["_blue"]  = df["close"] > df["open"]
+```
+
+### Tolerances (constraint #2 from Zerodha module: "be flexible — quantify and verify")
+- Marubozu: shadows up to 5% of range allowed
+- Hammer/Hanging Man: body in upper 1/3 of range; lower shadow >=2x body
+- Shooting Star: body in lower 1/3 of range; upper shadow >=2x body
+- Harami: child body fully inside parent body (open and close both within parent's open/close)
+- Engulfing: child body fully engulfs parent body
+- Piercing/Dark Cloud: penetrates >=50% of prior body
+
+### Output schema
+```sql
+CREATE TABLE "FE_CANDLESTICK_SIGNALS" (
+  id          bigint,             -- nullable, carries through from OHLCV when available
+  slug        text NOT NULL,
+  timestamp   timestamptz NOT NULL,
+  m_cnd_marubozu_bin       bigint DEFAULT 0,
+  m_cnd_hammer_bin         bigint DEFAULT 0,
+  m_cnd_hanging_man_bin    bigint DEFAULT 0,
+  m_cnd_shooting_star_bin  bigint DEFAULT 0,
+  m_cnd_engulfing_bin      bigint DEFAULT 0,
+  m_cnd_harami_bin         bigint DEFAULT 0,
+  m_cnd_piercing_bin       bigint DEFAULT 0,
+  m_cnd_dark_cloud_bin     bigint DEFAULT 0,
+  m_cnd_star_bin           bigint DEFAULT 0,
+  PRIMARY KEY (slug, timestamp)
+);
+```
+
+All 9 bin columns default to `0` (neutral) using `np.select(default=0)` — they never carry NULL, which keeps `gcp_dmv_core.py`'s NaN-handling cheap.
+
+### Write semantics
+- **dbcp**: TRUNCATE + INSERT (latest-per-slug snapshot)
+- **cp_backtest**: DELETE-by-timestamp + INSERT (accumulates history)
+- Both use `method="multi", chunksize=200` (v4.8.2) for ~10x faster writes
+
+## Integration Points
+- **Upstream**: `1K_coins_ohlcv` (110-day window)
+- **Downstream**: `FE_CANDLESTICK_SIGNALS` -> `FE_DMV_ALL` via JOIN in `gcp_dmv_core.py`
+- **Pipeline position**: Stage 3.7 (after `gcp_dmv_rat.py`, before `gcp_dmv_dow.py`)
+- **Score mapping**: All `m_cnd_*` bins start with `m_` -> aggregated into `Momentum_Score`
+
+## Usage
+```bash
+python gcp_postgres_sandbox/technical_analysis/gcp_dmv_candle.py
+# Runtime: ~1.5-2 minutes for 1000 cryptocurrencies (98k OHLCV rows)
+```
+
+## Migration & Backfill
+- Migration: `migrations/2026_05_11_phase2_candlestick.sql` (creates `FE_CANDLESTICK_SIGNALS` + extends `FE_DMV_ALL` with the 9 bin cols)
+- Historical backfill: `scripts/backfill_phase2_cp_backtest.py` (psycopg2 COPY for ~2.5 min over 1.13M rows)
+
+## Dependencies
+- `pandas>=2.2.2` — vectorised pattern detection
+- `numpy>=1.26.4` — np.select for bin assignment
+- `sqlalchemy>=2.0.32`, `pg8000>=1.31.5` — database connectivity
+
+## Key Features
+1. **9 directional patterns** covering Zerodha Module 2's full candle catalogue
+2. **No TA-Lib dependency** — avoids the GHA build pain entirely
+3. **Bigint bin convention** — `default=0` (no NULLs, no NaN propagation)
+4. **Prior-trend gate** keeps Hammer/Hanging Man semantics correct
+5. **Tolerance-based geometry** — "approximately" rather than "exactly" matches real-world candles

--- a/knowledge_base/gcp_dmv_core.md
+++ b/knowledge_base/gcp_dmv_core.md
@@ -3,182 +3,165 @@ Note: All sensitive configuration values are redacted in this document.
 # gcp_dmv_core.py - Central Signal Aggregation Hub
 
 ## Overview
-This script is the **final aggregation engine** of the CryptoPrism-DB system, serving as the central hub that merges all technical analysis signals from 5 different modules into unified DMV (Durability, Momentum, Valuation) scores and comprehensive signal matrices.
+This script is the **final aggregation engine** of the CryptoPrism-DB system, merging all technical analysis signals from 8 different signal tables into unified DMV (Durability, Momentum, Valuation) scores and a comprehensive signal matrix.
+
+As of v4.8.0 the JOIN spans 8 tables (was 5 prior to v4.8.0).
 
 ## Detailed Functionality
 
-### **Signal Collection Process**
-The script performs a **FULL OUTER JOIN** operation across 5 signal tables:
+### Signal Collection -- FULL OUTER JOIN of 8 tables
 
 ```sql
 SELECT *
 FROM "FE_OSCILLATORS_SIGNALS" AS o
-FULL OUTER JOIN "FE_MOMENTUM_SIGNALS" AS m USING (slug, timestamp)
-FULL OUTER JOIN "FE_METRICS_SIGNAL" AS me USING (slug, timestamp)  
-FULL OUTER JOIN "FE_TVV_SIGNALS" AS t USING (slug, timestamp)
-FULL OUTER JOIN "FE_RATIOS_SIGNALS" AS r USING (slug, timestamp);
+FULL OUTER JOIN "FE_MOMENTUM_SIGNALS"     AS m  USING (slug, timestamp)
+FULL OUTER JOIN "FE_METRICS_SIGNAL"       AS me USING (slug, timestamp)
+FULL OUTER JOIN "FE_TVV_SIGNALS"          AS t  USING (slug, timestamp)
+FULL OUTER JOIN "FE_RATIOS_SIGNALS"       AS r  USING (slug, timestamp)
+FULL OUTER JOIN "FE_CANDLESTICK_SIGNALS"  AS c  USING (slug, timestamp)  -- v4.8.0
+FULL OUTER JOIN "FE_DOW_PATTERNS"         AS d  USING (slug, timestamp)  -- v4.8.0
+FULL OUTER JOIN "FE_PRICE_LEVELS"         AS l  USING (slug, timestamp); -- v4.8.0
 ```
 
-### **Data Processing Pipeline**
+`FULL OUTER JOIN` means rows missing from any side contribute NULL for that side's columns. The downstream `.fillna(0)` converts those to neutral signals.
 
-#### **1. Data Cleaning & Validation**
+### Data Processing Pipeline
+
+#### 1. Data Cleaning (v4.8.1 + v4.8.3 fixes)
 ```python
-# Remove duplicate columns from JOIN operations
-df = df.loc[:, ~df.columns.duplicated()]
-
-# Smart filtering: Keep Bitcoin always + complete signal rows
-df = df.pipe(lambda d: d[d['slug'].eq('bitcoin') | 
-                       d.drop(columns='slug').notna().all(axis=1)])
-
-# Fill missing values with neutral signals (0)
-df = df.fillna(0)
+df = (
+    df.loc[:, ~df.columns.duplicated()]
+      .dropna(subset=['slug', 'timestamp'])     # v4.8.1
+      .fillna(0)                                 # NaN -> neutral signal
+)
 ```
 
-#### **2. Signal Aggregation (Bullish/Bearish/Neutral Counts)**
+**v4.8.1 fix**: the previous filter `d[d['slug'].eq('bitcoin') | d.drop(columns='slug').notna().all(axis=1)]` was collapsing `FE_DMV_ALL` to a single row (bitcoin) whenever any joined table lagged or had NaN. Replaced with a minimal `dropna(subset=['slug','timestamp'])` -- the existing `.fillna(0)` already handles missing signals correctly.
+
+#### 2. Bullish/Bearish/Neutral Counts
 ```python
-# Initialize signal counters
 for col in ['bullish', 'bearish', 'neutral']:
     df[col] = 0
 
-# Count signals across all indicators (columns 4 onwards)
 for index, row in df.iloc[:, 4:].iterrows():
-    df.at[index, 'bullish'] = (row == 1).sum()    # Buy signals
-    df.at[index, 'bearish'] = (row == -1).sum()   # Sell signals  
-    df.at[index, 'neutral'] = (row == 0).sum()    # Neutral signals
+    df.at[index, 'bullish'] = (row == 1).sum()
+    df.at[index, 'bearish'] = (row == -1).sum()
+    df.at[index, 'neutral'] = (row == 0).sum()
 ```
+Counts each row's signal columns by their bin value. Identifier columns (`slug`, `timestamp`, `id`, `name`) are skipped via the `iloc[:, 4:]` slice.
 
-#### **3. DMV Score Calculation**
+#### 3. v4.8.3 schema filter (FE_DMV_ALL write only)
+```python
+with gcp_engine.connect() as conn:
+    fe_dmv_all_cols = {r[0] for r in conn.execute(text(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_name='FE_DMV_ALL'"
+    )).fetchall()}
+df = df[[c for c in df.columns if c in fe_dmv_all_cols]]
+```
+**v4.8.3 fix**: the v4.8.0 JOIN extension pulled 12 value columns from `FE_DOW_PATTERNS` (m_dow_support, m_dow_resistance) and `FE_PRICE_LEVELS` (fib_swing_*, fib_0_*, atr_band_*) through `SELECT *`, but `FE_DMV_ALL`'s schema was extended with only the bin columns. The INSERT errored with column-not-found, hidden behind pg8000's "in failed transaction block" message. The schema filter dynamically discovers FE_DMV_ALL's columns from `information_schema` and trims the df to match.
 
-##### **Durability Signals (d_ prefix)**
+#### 4. DMV Score Calculation
+
+Scores are computed via prefix-based column mapping after the schema filter (so raw value columns like `m_dow_support` are already removed and don't pollute the Momentum sum).
+
 ```python
 Durability = df[['slug'] + [c for c in df.columns if c.startswith('d_')]]
+Momentum   = df[['slug'] + [c for c in df.columns if c.startswith('m_')]]
+Valuation  = df[['slug'] + [c for c in df.columns if c.startswith('v_')]]
+
 Durability['Durability_Score'] = Durability.drop('slug', axis=1).sum(axis=1) / (Durability.shape[1] - 1) * 100
+Momentum  ['Momentum_Score']   = Momentum  .drop('slug', axis=1).sum(axis=1) / (Momentum.shape[1] - 1) * 100
+Valuation ['Valuation_Score']  = Valuation .drop('slug', axis=1).sum(axis=1) / (Valuation.shape[1] - 1) * 100
 ```
-- **Purpose**: Long-term stability and risk assessment
-- **Components**: Risk metrics, volatility measures, drawdown indicators
-- **Scale**: 0-100 (higher = more durable/stable)
 
-##### **Momentum Signals (m_ prefix)**  
+Each score is a normalized 0-100 value (`sum / N-1 * 100`) where N is the number of columns. The denominator auto-scales as new bins land in each bucket.
+
+| Score | Prefix | Includes (v4.8.x) |
+|---|---|---|
+| Durability | `d_` | risk metrics, drawdown, beta, pain ratio, SMA/EMA crossovers |
+| Momentum | `m_` | RSI, ROC, Williams %R, OBV, BB, Supertrend, Aroon, candlesticks, dow patterns, fib proximity, ATR band |
+| Valuation | `v_` | Sharpe, Sortino, Treynor, common-sense, information, win/loss ratios |
+
+#### 5. Per-slug latest filtering (v4.4.x)
 ```python
-Momentum = df[['slug'] + [c for c in df.columns if c.startswith('m_')]]
-Momentum['Momentum_Score'] = Momentum.drop('slug', axis=1).sum(axis=1) / (Momentum.shape[1] - 1) * 100
+df = df.loc[df.groupby('slug')['timestamp'].idxmax()]
 ```
-- **Purpose**: Short-term price movement strength and direction
-- **Components**: RSI, ROC, Williams %R, momentum oscillators
-- **Scale**: 0-100 (higher = stronger bullish momentum)
+Keeps only the most recent timestamp **per slug** rather than a global max. Prevents dropping coins whose OHLCV is slightly behind the newest coin's bar.
 
-##### **Valuation Signals (v_ prefix)**
-```python  
-Valuation = df[['slug'] + [c for c in df.columns if c.startswith('v_')]]
-Valuation['Valuation_Score'] = Valuation.drop('slug', axis=1).sum(axis=1) / (Valuation.shape[1] - 1) * 100
-```
-- **Purpose**: Fundamental value assessment and market positioning
-- **Components**: Market cap ratios, ATH/ATL analysis, coin age metrics
-- **Scale**: 0-100 (higher = better valuation opportunity)
+### Output Tables
 
-#### **4. Latest Data Filtering**
-```python
-latest_timestamp = df['timestamp'].max()
-df = df[df['timestamp'] == latest_timestamp]
+#### FE_DMV_ALL (Complete Signal Matrix)
+- **Content**: All bin/signal columns (61 cols as of v4.8.0) + bullish/bearish/neutral counts
+- **Schema**: PK on (slug, timestamp). Bin columns only — value columns are filtered out by the v4.8.3 schema filter.
+- **Write mode (dbcp)**: TRUNCATE + INSERT (latest-per-slug snapshot)
+- **Write mode (cp_backtest)**: DELETE-by-timestamp + INSERT (accumulates history)
+- **Batching (v4.8.2)**: `method='multi', chunksize=200` -- ~10x faster than the prior row-by-row default
 
-# Validation check
-if df['timestamp'].nunique() == 1:
-    print("✅ Latest timestamp filtered.")
-else:
-    print("⚠️ Multiple timestamps still exist.")
-```
-
-### **Output Tables Generated**
-
-#### **FE_DMV_ALL** (Complete Signal Matrix)
-- **Content**: All aggregated signals with bullish/bearish/neutral counts
-- **Purpose**: Comprehensive view of all technical indicators
-- **Update Mode**: `if_exists='replace'` (latest data only)
-
-#### **FE_DMV_SCORES** (DMV Scoring System)
+#### FE_DMV_SCORES (Normalized 0-100 scores)
 ```python
 dmv_scores = pd.DataFrame({
     'slug': df['slug'],
-    'timestamp': df['timestamp'], 
+    'timestamp': df['timestamp'],
     'Durability_Score': Durability['Durability_Score'],
-    'Momentum_Score': Momentum['Momentum_Score'],
-    'Valuation_Score': Valuation['Valuation_Score']
+    'Momentum_Score':   Momentum['Momentum_Score'],
+    'Valuation_Score':  Valuation['Valuation_Score'],
 })
+dmv_scores.to_sql('FE_DMV_SCORES', con=gcp_engine, if_exists='append',
+                  index=False, method='multi', chunksize=BATCH_SIZE)
 ```
-- **Content**: Normalized 0-100 scores for each DMV category
-- **Purpose**: High-level cryptocurrency ranking and comparison
-- **Batch Size**: 10,000 records for optimized uploads
+`BATCH_SIZE = 10000`. Same TRUNCATE+INSERT pattern on dbcp; DELETE-by-timestamp+INSERT on cp_backtest.
 
-### **Performance Optimization**
-```python
-BATCH_SIZE = 10000
+### Error Handling & Monitoring
+Comprehensive logging with both file (`app.log`) and console output. Database operations wrapped in try/except around the score and cp_backtest writes. The FE_DMV_ALL write is unprotected — its failure is a hard stop.
 
-# Chunked database uploads for large datasets
-dmv_scores.to_sql('FE_DMV_SCORES', con=gcp_engine, 
-                  if_exists='replace', index=False, 
-                  method='multi', chunksize=BATCH_SIZE)
-```
+### Integration Points
+- **Upstream**: 8 signal tables (must all complete first)
+  - `FE_OSCILLATORS_SIGNALS` (gcp_dmv_osc.py)
+  - `FE_MOMENTUM_SIGNALS` (gcp_dmv_mom.py)
+  - `FE_METRICS_SIGNAL` (gcp_dmv_met.py)
+  - `FE_TVV_SIGNALS` (gcp_dmv_tvv.py)
+  - `FE_RATIOS_SIGNALS` (gcp_dmv_rat.py)
+  - `FE_CANDLESTICK_SIGNALS` (gcp_dmv_candle.py) -- v4.8.0
+  - `FE_DOW_PATTERNS` (gcp_dmv_dow.py) -- v4.8.0
+  - `FE_PRICE_LEVELS` (gcp_dmv_levels.py) -- v4.8.0
+- **Pipeline position**: **Final step** in DMV workflow (after the 10 indicator scripts)
+- **Downstream**: Feeds the QA system and downstream API/trading consumers
 
-### **Error Handling & Monitoring**
-```python
-# Comprehensive logging with file + console output
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s", 
-    handlers=[logging.FileHandler("app.log"), logging.StreamHandler()]
-)
-
-# Database operation error handling
-try:
-    dmv_scores.to_sql('FE_DMV_SCORES', con=gcp_engine, ...)
-    logger.info("FE_DMV_SCORES uploaded.")
-except SQLAlchemyError as e:
-    logger.error(f"Error uploading scores: {e}")
-    exit(1)
-
-# Execution time tracking
-start_time = time.time()
-logger.info(f"Done in {(time.time() - start_time) / 60:.2f} mins.")
-```
-
-### **Integration Points**
-- **Upstream Dependencies**: All 5 signal modules must complete first
-  - `FE_OSCILLATORS_SIGNALS` (from gcp_dmv_osc.py)
-  - `FE_MOMENTUM_SIGNALS` (from gcp_dmv_mom.py) 
-  - `FE_METRICS_SIGNAL` (from gcp_dmv_met.py)
-  - `FE_TVV_SIGNALS` (from gcp_dmv_tvv.py)
-  - `FE_RATIOS_SIGNALS` (from gcp_dmv_rat.py)
-- **Pipeline Position**: **Final step** in DMV workflow (Stage 3.8)
-- **Downstream**: Feeds QA systems and trading algorithms
-
-### **Database Schema**
+### Database Schema
 ```sql
--- FE_DMV_ALL table (complete signal aggregation)
-slug, timestamp, [all_signal_columns], bullish, bearish, neutral
+-- FE_DMV_ALL: 61 columns (post v4.8.0). All bin/signal cols + 3 counters.
+slug, timestamp, id, name,
+m_osc_*, m_mom_*, m_pct_*, m_tvv_*, m_rat_*, m_cnd_*, m_dow_*_bin, m_lvl_*_bin,
+d_pct_*, d_met_*, d_tvv_*, d_rat_*,
+v_rat_*,
+bullish, bearish, neutral
 
--- FE_DMV_SCORES table (normalized scoring)  
-slug, timestamp, Durability_Score, Momentum_Score, Valuation_Score
+-- FE_DMV_SCORES: normalized aggregates
+slug, timestamp, "Durability_Score", "Momentum_Score", "Valuation_Score"
 ```
 
 ## Usage
 ```bash
-# Manual execution (requires all upstream signals)
-python gcp_postgres_sandbox/gcp_dmv_core.py
-
-# Automated via GitHub Actions (DMV workflow)  
-# Runs as FINAL step after all other DMV modules
+python gcp_postgres_sandbox/technical_analysis/gcp_dmv_core.py
+# Runtime: ~1.5-2 minutes (post v4.8.2 batched INSERTs); previously ~5-10 min
 ```
 
 ## Dependencies
-- pandas>=2.2.2 - Data manipulation and aggregation
-- numpy>=1.26.4 - Numerical operations for signal counting
-- sqlalchemy>=2.0.32 - Database operations with error handling  
-- psycopg2-binary>=2.9.9 - PostgreSQL connectivity
-- time - Performance monitoring
-- logging - Comprehensive progress tracking
+- `pandas>=2.2.2` -- aggregation
+- `numpy>=1.26.4`
+- `sqlalchemy>=2.0.32`, `pg8000>=1.31.5` -- DB connectivity (note: pg8000 surfaces INSERT errors poorly; see v4.8.3/v4.8.4 changelog entries)
+- `time`, `logging`
+
+## Recent Changes
+- **v4.8.4** (2026-05-13): pd.NA dtype fix in upstream candle/dow/levels scripts (id column). Indirectly required for core to receive valid input.
+- **v4.8.3** (2026-05-13): Added dynamic FE_DMV_ALL schema filter (line 95-99). Drops 12 phantom value columns introduced by the v4.8.0 JOIN extension.
+- **v4.8.2** (2026-05-13): FE_DMV_ALL write now uses `method='multi', chunksize=200`.
+- **v4.8.1** (2026-05-13): Replaced the bitcoin-OR-non-null filter with `dropna(subset=['slug','timestamp'])`. Fixed FE_DMV_ALL collapsing to 1 row.
+- **v4.8.0** (2026-05-11): JOIN extended from 5 to 8 tables to incorporate new candlestick, Dow, and Fibonacci/ATR signals.
 
 ## Key Outputs
-1. **Signal Aggregation**: 100+ technical indicators merged into unified view
-2. **DMV Scoring**: Normalized 0-100 scores for systematic comparison  
-3. **Signal Counts**: Bullish/bearish/neutral tallies for quick assessment
-4. **Latest Data**: Real-time filtering for current market analysis
+1. **Signal aggregation**: 100+ technical indicators merged into a unified view
+2. **DMV scoring**: Normalized 0-100 scores for systematic ranking
+3. **Bullish/bearish/neutral counts**: Quick assessment of overall stance per slug
+4. **Per-slug latest snapshot** on dbcp, **timestamped history** on cp_backtest

--- a/knowledge_base/gcp_dmv_dow.md
+++ b/knowledge_base/gcp_dmv_dow.md
@@ -1,0 +1,138 @@
+# gcp_dmv_dow.py - Dow Theory Price-Action Pattern Detector
+
+## Overview
+This script detects **Dow Theory price-action patterns** (support/resistance, double/triple tops & bottoms, range breakouts, flags) using `scipy.signal.find_peaks`. Added in v4.8.0 (Phase 3 of the DMV indicator expansion). Outputs go to `FE_DOW_PATTERNS` and feed into `FE_DMV_ALL` via the FULL OUTER JOIN in `gcp_dmv_core.py`.
+
+## Detected Patterns
+
+### Value columns (raw price levels, nullable)
+| Column | Type | Meaning |
+|---|---|---|
+| `m_dow_support` | `double precision` | Most recent twice-tested swing low within 60-bar window |
+| `m_dow_resistance` | `double precision` | Most recent twice-tested swing high within 60-bar window |
+
+NULL when no twice-tested level exists for the slug — ~60% of slugs are NULL on a given day, which is expected (most coins don't have a clean double-tested swing within 60 bars).
+
+### Bin columns (signal, default=0)
+| Column | Trigger | Direction |
+|---|---|---|
+| `m_dow_dbl_top_bin` | Two swing highs ~equal price | -1 |
+| `m_dow_dbl_bot_bin` | Two swing lows ~equal price | +1 |
+| `m_dow_trpl_top_bin` | Three swing highs ~equal price | -1 |
+| `m_dow_trpl_bot_bin` | Three swing lows ~equal price | +1 |
+| `m_dow_range_break_up_bin` | Close > prior resistance with >=1.3x avg volume | +1 |
+| `m_dow_range_break_dn_bin` | Close < prior support with >=1.3x avg volume | -1 |
+| `m_dow_flag_bin` | 10%+ move over prior 15 bars + tight 5-bar range (<=3%) | +1 / -1 |
+
+## Detailed Functionality
+
+### Swing detection
+```python
+from scipy.signal import find_peaks
+
+DISTANCE = 5           # min separation between peaks (bars)
+PRICE_TOLERANCE = 0.02 # 2% tolerance when comparing two peak/trough prices
+BREAKOUT_VOL_RATIO = 1.3
+LOOKBACK_BARS = 60
+```
+- `find_peaks(closes, distance=5)` -> swing highs
+- `find_peaks(-closes, distance=5)` -> swing lows
+- Two levels considered "equal" if their price difference is within 2% of either price
+
+### Per-slug processing
+```python
+def _detect_per_slug(g):
+    """Compute all Dow pattern values + bins for one slug's history."""
+    g = g.reset_index(drop=True)
+    n = len(g)
+    out = {
+        "m_dow_support": np.nan,
+        "m_dow_resistance": np.nan,
+        "m_dow_dbl_top_bin": 0,
+        "m_dow_dbl_bot_bin": 0,
+        # ...all bins default to 0
+    }
+    if n < DISTANCE * 2 + 1:
+        return pd.Series(out)
+    # ... detection logic on the last 60 bars
+```
+- Slugs with <11 bars: all values/bins return defaults (NaN for values, 0 for bins)
+- Slugs with >=60 bars: detection runs on the trailing 60-bar window for relevance + performance
+
+### Flag pattern logic
+```python
+if nW >= 20:
+    recent5_high = highs[-5:].max()
+    recent5_low  = lows[-5:].min()
+    recent5_range_pct = (recent5_high - recent5_low) / max(recent5_low, 1e-9)
+
+    prior15_close_start = closes[-20]
+    prior15_close_end   = closes[-6]
+    prior_move_pct = (prior15_close_end - prior15_close_start) / max(abs(prior15_close_start), 1e-9)
+
+    if recent5_range_pct <= 0.03 and abs(prior_move_pct) >= 0.10:
+        out["m_dow_flag_bin"] = 1 if prior_move_pct > 0 else -1
+```
+A flag is a sharp ~10%+ move followed by a tight (<=3%) 5-bar consolidation. The bin direction follows the prior move's direction.
+
+### Output schema
+```sql
+CREATE TABLE "FE_DOW_PATTERNS" (
+  id          bigint,             -- nullable
+  slug        text NOT NULL,
+  timestamp   timestamptz NOT NULL,
+  m_dow_support     double precision,   -- nullable
+  m_dow_resistance  double precision,   -- nullable
+  m_dow_dbl_top_bin          bigint DEFAULT 0,
+  m_dow_dbl_bot_bin          bigint DEFAULT 0,
+  m_dow_trpl_top_bin         bigint DEFAULT 0,
+  m_dow_trpl_bot_bin         bigint DEFAULT 0,
+  m_dow_range_break_up_bin   bigint DEFAULT 0,
+  m_dow_range_break_dn_bin   bigint DEFAULT 0,
+  m_dow_flag_bin             bigint DEFAULT 0,
+  PRIMARY KEY (slug, timestamp)
+);
+```
+
+### v4.8.4 dtype fix
+The script sets `out["id"] = pd.NA` to leave id NULL. Previously this created an `object`-dtype column of Python `None`, which pg8000 refused to bind for a bigint column (the `to_sql` failed silently with "in failed transaction block"). v4.8.4 changed it to:
+```python
+out["id"] = pd.array([pd.NA] * len(out), dtype="Int64")
+```
+Same intent (NULL in postgres), but a dtype pg8000 can serialize.
+
+### v4.8.3 downstream filter
+Because the script writes 2 value columns (`m_dow_support`, `m_dow_resistance`) that `FE_DMV_ALL`'s schema does NOT have, the `SELECT *` JOIN in `gcp_dmv_core.py` previously pulled them through and the FE_DMV_ALL INSERT failed. v4.8.3 added a dynamic `information_schema` filter in core.py that trims the df to only FE_DMV_ALL's columns before INSERT — see `knowledge_base/gcp_dmv_core.md`.
+
+### Write semantics
+- **dbcp**: TRUNCATE + INSERT (latest-per-slug snapshot)
+- **cp_backtest**: DELETE-by-timestamp + INSERT (accumulates history)
+- Both use `method="multi", chunksize=200` (v4.8.2)
+
+## Integration Points
+- **Upstream**: `1K_coins_ohlcv` (110-day window)
+- **Downstream**: `FE_DOW_PATTERNS` -> `FE_DMV_ALL` (bin cols only — value cols are stripped by the v4.8.3 schema filter in core.py)
+- **Pipeline position**: Stage 3.8 (after `gcp_dmv_candle.py`, before `gcp_dmv_levels.py`)
+- **Score mapping**: All `m_dow_*_bin` columns -> `Momentum_Score`. The value cols `m_dow_support` / `m_dow_resistance` are pre-filtered out by core.py so they don't pollute the score with raw price magnitudes.
+
+## Usage
+```bash
+python gcp_postgres_sandbox/technical_analysis/gcp_dmv_dow.py
+# Runtime: ~1.5-2 minutes for 1000 cryptocurrencies
+```
+
+## Migration & Backfill
+- Migration: `migrations/2026_05_11_phase3_dow.sql` (creates `FE_DOW_PATTERNS` + extends `FE_DMV_ALL` with the 7 bin cols, NOT the 2 value cols)
+- Historical backfill: `scripts/backfill_phase3_5_cp_backtest.py`
+
+## Dependencies
+- `scipy>=1.13.0` — `scipy.signal.find_peaks` for swing detection
+- `pandas>=2.2.2`, `numpy>=1.26.4`
+- `sqlalchemy>=2.0.32`, `pg8000>=1.31.5`
+
+## Key Features
+1. **Swing-based detection** using `scipy.signal.find_peaks` rather than naive local-extrema scans
+2. **Tolerance-based equality** (2%) for "twice-tested level" patterns
+3. **Volume-confirmed breakouts** (1.3x 10-day average) — filters whipsaw noise
+4. **60-bar rolling window** balances pattern recency with performance
+5. **Bigint bins default to 0** — no NULL pollution into DMV scores

--- a/knowledge_base/gcp_dmv_levels.md
+++ b/knowledge_base/gcp_dmv_levels.md
@@ -1,0 +1,122 @@
+# gcp_dmv_levels.py - Fibonacci Retracements & ATR Bands
+
+## Overview
+This script computes **Fibonacci retracement levels** and an **ATR-based volatility envelope** per slug. Added in v4.8.0 (Phase 5 of the DMV indicator expansion — the final indicators from Zerodha Varsity Module 2). Outputs go to `FE_PRICE_LEVELS` and feed into `FE_DMV_ALL` via the FULL OUTER JOIN in `gcp_dmv_core.py`.
+
+## Computed Levels
+
+### Value columns (raw price levels, nullable)
+| Column | Type | Meaning |
+|---|---|---|
+| `fib_swing_low` | `double precision` | Most recent swing low (anchor for retracement) |
+| `fib_swing_high` | `double precision` | Most recent swing high (anchor for retracement) |
+| `fib_0_236` | `double precision` | 23.6% retracement level |
+| `fib_0_382` | `double precision` | 38.2% retracement level |
+| `fib_0_500` | `double precision` | 50% retracement level |
+| `fib_0_618` | `double precision` | 61.8% retracement level (golden ratio) |
+| `fib_0_786` | `double precision` | 78.6% retracement level |
+| `atr_band_mid` | `double precision` | 5-period SMA of close |
+| `atr_band_upper` | `double precision` | mid + 3 * ATR(14) |
+| `atr_band_lower` | `double precision` | mid - 3 * ATR(14) |
+
+NULL on slugs with <16 bars (need ATR period + 2). On 1000 coins, typically ~36-38 NULLs.
+
+### Bin columns (signal, default=0)
+| Column | Trigger | Direction |
+|---|---|---|
+| `m_lvl_fib_proximity_bin` | Close within 1% of `fib_0_382` or `fib_0_618` | +1 (buying retracement) |
+| `m_lvl_fib_proximity_bin` | Close within 1% of `fib_0_236` | -1 (shallow rejection) |
+| `m_lvl_atr_band_bin` | Close < `atr_band_lower` | +1 (oversold envelope) |
+| `m_lvl_atr_band_bin` | Close > `atr_band_upper` | -1 (overbought envelope) |
+
+## Detailed Functionality
+
+### Constants
+```python
+SWING_DISTANCE = 5      # find_peaks min separation
+LOOKBACK       = 60     # bars used per slug
+PROXIMITY_PCT  = 0.01   # 1% band around fib levels
+ATR_PERIOD     = 14
+SMA_PERIOD     = 5
+ATR_BAND_MULT  = 3.0
+```
+
+### Swing anchors
+```python
+high_idx, _ = find_peaks(closes,  distance=SWING_DISTANCE)
+low_idx,  _ = find_peaks(-closes, distance=SWING_DISTANCE)
+
+if len(high_idx) >= 1 and len(low_idx) >= 1:
+    anchor_high_idx = int(high_idx[-1])
+    anchor_low_idx  = int(low_idx[-1])
+    # Order them so high > low
+    if anchor_high_idx > anchor_low_idx:
+        swing_low  = float(closes[anchor_low_idx])
+        swing_high = float(closes[anchor_high_idx])
+        # ... compute fib retracement levels
+```
+Most recent peak + trough within the 60-bar window are the swing anchors. Retracement levels are computed from there.
+
+### ATR-band envelope
+The mid line is a 5-SMA of close (short-term, responsive). The upper/lower bands are mid +/- 3 * ATR(14). At 3 sigma, breaches signal genuine overbought/oversold rather than ordinary noise.
+
+### Output schema
+```sql
+CREATE TABLE "FE_PRICE_LEVELS" (
+  id          bigint,             -- nullable
+  slug        text NOT NULL,
+  timestamp   timestamptz NOT NULL,
+  fib_swing_low      double precision,
+  fib_swing_high     double precision,
+  fib_0_236          double precision,
+  fib_0_382          double precision,
+  fib_0_500          double precision,
+  fib_0_618          double precision,
+  fib_0_786          double precision,
+  atr_band_mid       double precision,
+  atr_band_upper     double precision,
+  atr_band_lower     double precision,
+  m_lvl_fib_proximity_bin   bigint DEFAULT 0,
+  m_lvl_atr_band_bin        bigint DEFAULT 0,
+  PRIMARY KEY (slug, timestamp)
+);
+```
+
+### v4.8.4 dtype fix
+Same pattern as `gcp_dmv_dow.py`: `out["id"] = pd.NA` was producing an object-dtype column of Python `None` which pg8000 refused for bigint binding. v4.8.4 uses `pd.array([pd.NA] * len(out), dtype="Int64")`.
+
+### v4.8.3 schema filter
+`FE_DMV_ALL` only holds the 2 bin columns from this table -- the 10 value columns (fib_swing_*, fib_0_*, atr_band_*) are NOT in FE_DMV_ALL's schema. The schema filter in `gcp_dmv_core.py` (v4.8.3) drops these from the df before INSERT to FE_DMV_ALL.
+
+### Write semantics
+- **dbcp**: TRUNCATE + INSERT (latest-per-slug snapshot)
+- **cp_backtest**: DELETE-by-timestamp + INSERT (accumulates history)
+- Both use `method="multi", chunksize=200` (v4.8.2)
+
+## Integration Points
+- **Upstream**: `1K_coins_ohlcv` (110-day window)
+- **Downstream**: `FE_PRICE_LEVELS` -> `FE_DMV_ALL` (only the 2 bin cols flow through; value cols stripped by core.py's schema filter)
+- **Pipeline position**: Stage 3.9 (after `gcp_dmv_dow.py`, before `gcp_dmv_core.py` — the final analytical step)
+- **Score mapping**: `m_lvl_fib_proximity_bin` and `m_lvl_atr_band_bin` -> `Momentum_Score`
+
+## Usage
+```bash
+python gcp_postgres_sandbox/technical_analysis/gcp_dmv_levels.py
+# Runtime: ~1.5-2 minutes for 1000 cryptocurrencies
+```
+
+## Migration & Backfill
+- Migration: `migrations/2026_05_11_phase5_levels.sql` (creates `FE_PRICE_LEVELS` + extends `FE_DMV_ALL` with the 2 bin cols, NOT the 10 value cols)
+- Historical backfill: `scripts/backfill_phase3_5_cp_backtest.py`
+
+## Dependencies
+- `scipy>=1.13.0` — `scipy.signal.find_peaks` for swing detection
+- `pandas>=2.2.2`, `numpy>=1.26.4`
+- `sqlalchemy>=2.0.32`, `pg8000>=1.31.5`
+
+## Key Features
+1. **Standard Fibonacci ratios** (0.236, 0.382, 0.5, 0.618, 0.786) anchored on detected swings
+2. **ATR-band envelope** at 3 sigma for true overbought/oversold signals
+3. **1% proximity tolerance** on Fib levels — captures "near level" without false-positive noise
+4. **Most-recent-swing anchoring** — Fib levels update as new swings form, not frozen on first peak/trough
+5. **Bigint bins default to 0** — no NaN propagation into DMV scores

--- a/knowledge_base/gcp_dmv_met.md
+++ b/knowledge_base/gcp_dmv_met.md
@@ -382,3 +382,6 @@ CREATE TABLE FE_METRICS_SIGNAL (
 8. **Performance Monitoring**: Runtime tracking and optimization
 9. **Time Series Processing**: Efficient grouped calculations for 1000+ cryptocurrencies
 10. **DMV Framework Integration**: Feeds Durability, Momentum, and Valuation signals
+
+## Recent Changes
+- **v4.8.2** (2026-05-13): All 4 `to_sql` calls (FE_METRICS + FE_METRICS_SIGNAL, dbcp + cp_backtest) now use `method='multi', chunksize=200` -- ~10x faster writes over a high-latency link to Cloud SQL postgres.

--- a/knowledge_base/gcp_dmv_mom.md
+++ b/knowledge_base/gcp_dmv_mom.md
@@ -147,3 +147,6 @@ tsi, momentum_10, [additional momentum metrics...]
 slug, timestamp, m_rsi_9_signal, m_rsi_54_signal,
 m_williams_r_signal, m_roc_signal, m_momentum_signal
 ```
+
+## Recent Changes
+- **v4.8.2** (2026-05-13): Both `to_sql` calls (FE_MOMENTUM_SIGNALS to dbcp + cp_backtest) now use `method='multi', chunksize=200` -- ~10x faster writes.

--- a/knowledge_base/gcp_dmv_osc.md
+++ b/knowledge_base/gcp_dmv_osc.md
@@ -92,6 +92,29 @@ def calculate_trix(df, period=15):
 - **Signal**: Rate of change of triple-smoothed EMA
 - **Trend Identification**: Positive TRIX = uptrend, Negative = downtrend
 
+#### **7. Supertrend (v4.7.0)**
+```python
+def calculate_supertrend(df, atr_period=10, multiplier=3.0):
+    # hl2 = (high + low) / 2; basic upper = hl2 + multiplier * ATR(10)
+    # The "final" upper/lower bands carry forward across bars with a flip rule
+    # tied to close vs prior final band.
+```
+- **Components**: 10-period ATR; basic and final upper/lower bands; direction line
+- **Output columns**: `Supertrend_Line` (double precision), `Supertrend_Dir` (double precision)
+- **Bin signal**: `m_osc_supertrend_bin` in `FE_OSCILLATORS_SIGNALS` -- +1 when price closes above Supertrend line, -1 when below
+- **Per-slug stateful loop**: required because final bands depend on prior bar's final band and close
+
+#### **8. Aroon (v4.7.0)**
+```python
+def calculate_aroon(df, period=14):
+    # Aroon_Up   = 100 * (period - bars_since_highest_high) / period
+    # Aroon_Down = 100 * (period - bars_since_lowest_low) / period
+    # Aroon_Osc  = Aroon_Up - Aroon_Down
+```
+- **Output columns**: `Aroon_Up`, `Aroon_Down`, `Aroon_Osc` (all double precision)
+- **Range**: 0-100 each; oscillator -100 to +100
+- **Bin signal**: `m_osc_aroon_bin` in `FE_OSCILLATORS_SIGNALS` -- +1 when Aroon_Osc > 50, -1 when < -50, 0 otherwise (`np.select(default=0)`)
+
 ### **Binary Signal Generation**
 
 #### **Signal Logic Framework**
@@ -161,5 +184,12 @@ CREATE TABLE FE_OSCILLATORS_SIGNALS (
     m_osc_uo_bin INTEGER,              -- Ultimate Oscillator signal (-1,0,1)
     m_osc_ao_bin INTEGER,              -- Awesome Oscillator signal (-1,0,1)
     m_osc_trix_bin INTEGER             -- TRIX trend signal (-1,0,1)
+    , m_osc_supertrend_bin INTEGER     -- Supertrend signal (-1,0,1) -- v4.7.0
+    , m_osc_aroon_bin INTEGER          -- Aroon oscillator signal (-1,0,1) -- v4.7.0
 );
 ```
+
+## Recent Changes
+- **v4.8.2** (2026-05-13): Both `to_sql` calls (FE_OSCILLATORS_SIGNALS to dbcp + cp_backtest) now use `method='multi', chunksize=200` -- ~10x faster writes.
+- **v4.7.1** (2026-05-11): Bigint bins (`m_osc_supertrend_bin`, `m_osc_aroon_bin`) use `np.select(default=0)` so they default to 0 (neutral) rather than NULL. Matches the long-standing bigint-bin convention; aligns with `dmv_core.py`'s NaN-handling.
+- **v4.7.0** (2026-05-11): Added Supertrend (`Supertrend_Line/Dir` + `m_osc_supertrend_bin`) and Aroon (`Aroon_Up/Down/Osc` + `m_osc_aroon_bin`). See sections "7. Supertrend" and "8. Aroon" above.

--- a/knowledge_base/gcp_dmv_pct.md
+++ b/knowledge_base/gcp_dmv_pct.md
@@ -166,3 +166,6 @@ CREATE TABLE FE_PCT (
 5. **Data Quality Assurance**: Comprehensive cleaning and validation pipeline
 6. **Dual Database Architecture**: Production and backtesting data separation
 7. **Performance Monitoring**: Runtime tracking and optimization capabilities
+
+## Recent Changes
+- **v4.8.2** (2026-05-13): Both `to_sql` calls (FE_PCT to dbcp + cp_backtest) now use `method='multi', chunksize=200` -- ~10x faster writes.

--- a/knowledge_base/gcp_dmv_rat.md
+++ b/knowledge_base/gcp_dmv_rat.md
@@ -193,3 +193,6 @@ CREATE TABLE FE_RATIOS_SIGNALS (
     d_rat_pain_bin INTEGER            -- Gain to pain ratio signal (-1,0,1)
 );
 ```
+
+## Recent Changes
+- **v4.8.2** (2026-05-13): Both `to_sql` calls (FE_RATIOS_SIGNALS to dbcp + cp_backtest) now use `method='multi', chunksize=200` -- ~10x faster writes.

--- a/knowledge_base/gcp_dmv_tvv.md
+++ b/knowledge_base/gcp_dmv_tvv.md
@@ -75,6 +75,25 @@ def calculate_donchian_channels(df, period=21):
 - **Trend Following**: Breakouts above/below channels signal trend continuation
 - **Support/Resistance**: Channel boundaries act as dynamic support/resistance
 
+#### **6. Bollinger Bands (v4.7.0)**
+```python
+def calculate_bollinger_bands(df, period=20, num_std=2.0):
+    df["BB_Mid"]   = df.groupby("slug")["close"].transform(
+        lambda s: s.rolling(period, min_periods=period).mean())
+    rolling_std    = df.groupby("slug")["close"].transform(
+        lambda s: s.rolling(period, min_periods=period).std())
+    df["BB_Upper"] = df["BB_Mid"] + num_std * rolling_std
+    df["BB_Lower"] = df["BB_Mid"] - num_std * rolling_std
+    df["BB_Width"] = (df["BB_Upper"] - df["BB_Lower"]) / df["BB_Mid"]
+    df["BB_Pct_B"] = (df["close"] - df["BB_Lower"]) / (df["BB_Upper"] - df["BB_Lower"])
+```
+- **Output columns** (in `FE_TVV`): `BB_Mid`, `BB_Upper`, `BB_Lower`, `BB_Width`, `BB_Pct_B`
+- **Bin signal**: `m_tvv_bb_bin` (double precision, NaN-propagating) in `FE_TVV_SIGNALS`:
+  - +1 when close > BB_Upper (overbought / strong uptrend continuation)
+  - -1 when close < BB_Lower (oversold / strong downtrend continuation)
+  - 0 inside the bands
+- **Convention note (v4.7.1)**: FE_TVV_SIGNALS is `double precision` and preserves NaN propagation. Bigint signal tables (FE_OSCILLATORS_SIGNALS etc.) use `np.select(default=0)` instead. Both conventions are intentional and CHANGELOG-documented.
+
 ### **Binary Signal Generation**
 ```python
 # Volume-based signals
@@ -119,3 +138,7 @@ python gcp_postgres_sandbox/gcp_dmv_tvv.py
 4. **Channel Analysis**: Keltner and Donchian channel systems
 5. **Signal Generation**: Volume and trend-based binary signals
 6. **Dual Database Output**: Production and backtesting data separation
+
+## Recent Changes
+- **v4.8.2** (2026-05-13): Both `push_to_db` paths now use `method="multi", chunksize=200` on the `to_sql` call. Full pipeline (data fetch + indicator compute + 4 table writes) drops from ~14 min to ~3.6 min.
+- **v4.7.0** (2026-05-11): Added Bollinger Bands (`BB_Mid/Upper/Lower/Width/Pct_B` value columns + `m_tvv_bb_bin` signal). See section "6. Bollinger Bands" above.


### PR DESCRIPTION
## Summary
Knowledge-base docs catch up with the v4.7.0-v4.8.4 indicator expansion shipped in PRs #32-#36.

## New docs (3 — for scripts added in v4.8.0 that had no knowledge_base entry)
- \`gcp_dmv_candle.md\` — 9 directional candlestick patterns
- \`gcp_dmv_dow.md\` — Dow Theory price-action (support/resistance, double/triple tops & bottoms, range breakouts, flag)
- \`gcp_dmv_levels.md\` — Fibonacci retracements + ATR-band envelope

Each includes: detected patterns table, detailed logic + tolerances, output schema, write semantics, v4.8.x fix notes, integration points, dependencies.

## Updated docs (7)
| File | Change |
|---|---|
| \`gcp_dmv_core.md\` | Rewritten — JOIN extended from 5 to 8 tables (v4.8.0), bitcoin-OR-non-null filter replaced with \`dropna(subset=['slug','timestamp'])\` (v4.8.1), dynamic FE_DMV_ALL schema filter documented (v4.8.3), batched INSERTs (v4.8.2). \"Recent Changes\" section added with each version's one-liner. |
| \`gcp_dmv_tvv.md\` | Added Bollinger Bands section (v4.7.0). Recent Changes footer for v4.8.2. |
| \`gcp_dmv_osc.md\` | Added Supertrend and Aroon sections (v4.7.0). Recent Changes footer for v4.8.2. |
| \`gcp_dmv_met.md\` \`gcp_dmv_mom.md\` \`gcp_dmv_pct.md\` \`gcp_dmv_rat.md\` | Recent Changes footer for v4.8.2 batched INSERTs. |

## Test plan
- [ ] Render-check the markdown in GitHub UI for the 3 new docs
- [ ] Spot-check internal references against the actual scripts they document

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)