### PR TITLE
fix: surface real PG error in gcp_dmv_dow.py push_to_db (v4.8.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to the CryptoPrism-DB project will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.8.5] - 2026-05-13 UTC
+
+### Changed
+- **gcp_dmv_dow.py: added row-level fallback diagnostics to `push_to_db` and `push_to_db_backtest`.** Both functions now route through a new `_insert_with_row_diagnostics` helper that first attempts the fast batched INSERT (`method="multi", chunksize=200`), and on failure re-issues each row in an isolated transaction so pg8000's "in failed transaction block" cascade is broken. Each failing row is logged with its actual PG error and full row contents (up to 10 failures, then stops to avoid log spam). A `RuntimeError` is then raised so CI still fails loudly — but with a useful error.
+
+### Rationale
+**Why:** DMV run #457 on 2026-05-13 05:11 UTC failed in `gcp_dmv_dow.py`'s `to_sql` to `FE_DOW_PATTERNS` with the same useless "in failed transaction block" cascade we keep hitting (v4.8.1, v4.8.3, v4.8.4 all required probe scripts to surface the real error). Local probes against current data succeeded — the bug was data-transient and the failing row was already overwritten by the next OHLCV refresh, so the actual cause was unrecoverable from logs. A manual workflow_dispatch re-run (#459) completed `gcp_dmv_dow.py` successfully, confirming the v4.8.4 fix holds structurally; the failure was a one-off bad row from that morning's OHLCV refresh.
+
+**How to apply:** No DDL. Happy path is unchanged — when the batched INSERT succeeds, the helper returns immediately. The diagnostics path only runs on failure and only on the one DMV stage (dow) that has historically masked errors most often. If this proves valuable on the next recurrence, the same helper pattern can be lifted into `gcp_dmv_levels.py` and `gcp_dmv_candle.py` (and eventually the rest of the DMV scripts).
+
+### Impact Analysis
+- Risk: Very low. Happy path unchanged. Failure path is strictly more informative.
+- Performance: zero overhead on success. On failure, the fallback walks 1000 rows row-by-row (~30–60s estimated) before raising; previously the script aborted in <1s but yielded no useful diagnostic. Acceptable trade for the visibility.
+- Re-raise behaviour: failures still propagate, so CI status remains correct and the DMV workflow halts before downstream `gcp_dmv_levels.py` / `gcp_dmv_core.py` run on stale state.
+- Scope: dow only. Levels and candle use the same brittle pattern but did not fail on #457; deferred until needed.
+
 ## [4.8.4] - 2026-05-13 UTC
 
 ### Fixed

--- a/gcp_postgres_sandbox/technical_analysis/gcp_dmv_dow.py
+++ b/gcp_postgres_sandbox/technical_analysis/gcp_dmv_dow.py
@@ -208,11 +208,53 @@ BIN_COLS = [
 ]
 
 
+def _insert_with_row_diagnostics(df, table_name, engine, db_label):
+    # Why: pg8000's "in failed transaction block" cascade hides the real PG
+    # error when a batched multi-INSERT poisons the transaction. On failure,
+    # fall back to per-row INSERT in isolated transactions so the offending
+    # row's actual error surfaces in the logs. Re-raise after diagnostics.
+    try:
+        df.to_sql(table_name, con=engine, if_exists="append",
+                  index=False, method="multi", chunksize=200)
+        return
+    except Exception as fast_err:
+        logger.error(
+            "Batched INSERT into %s (%s) failed; falling back to row-by-row "
+            "to surface real PG error. Masked error: %s: %s",
+            table_name, db_label, type(fast_err).__name__, fast_err,
+        )
+
+    n_rows = len(df)
+    failures = []
+    for i in range(n_rows):
+        row = df.iloc[i:i + 1]
+        try:
+            with engine.begin() as conn:
+                row.to_sql(table_name, con=conn, if_exists="append",
+                           index=False, method=None)
+        except Exception as row_err:
+            failures.append(i)
+            logger.error(
+                "Row %d/%d failed INSERT into %s (%s): %s: %s | row=%s",
+                i, n_rows, table_name, db_label,
+                type(row_err).__name__, row_err,
+                row.iloc[0].to_dict(),
+            )
+            if len(failures) >= 10:
+                logger.error("Stopping row diagnostics after 10 failures.")
+                break
+
+    raise RuntimeError(
+        f"INSERT into {table_name} ({db_label}) failed; "
+        f"{len(failures)} bad row(s) logged above (of {n_rows} total)."
+    )
+
+
 def push_to_db(df, table_name, engine):
     with engine.connect() as conn:
         conn.execute(text(f'TRUNCATE TABLE "{table_name}"'))
         conn.commit()
-    df.to_sql(table_name, con=engine, if_exists="append", index=False, method="multi", chunksize=200)
+    _insert_with_row_diagnostics(df, table_name, engine, "dbcp")
     logger.info(f"{table_name} (dbcp) uploaded.")
 
 
@@ -226,7 +268,7 @@ def push_to_db_backtest(df, table_name, engine):
                     {"ts": ts},
                 )
             conn.commit()
-    df.to_sql(table_name, con=engine, if_exists="append", index=False, method="multi", chunksize=200)
+    _insert_with_row_diagnostics(df, table_name, engine, "cp_backtest")
     logger.info(f"{table_name} (cp_backtest) appended.")
 
 


### PR DESCRIPTION
## Summary
- DMV run [#457](https://github.com/CryptoPrism-io/CryptoPrism-DB-D/actions/runs/25778875612) failed in `gcp_dmv_dow.py` with pg8000's `InterfaceError: in failed transaction block` — the same useless cascade error that has masked the real cause in v4.8.1, v4.8.3, and v4.8.4.
- Manual re-run [#459](https://github.com/CryptoPrism-io/CryptoPrism-DB-D/actions/runs/25801896641) succeeded with **no code change**, confirming the failure was data-transient. But the offending row was already overwritten by the next OHLCV refresh, so the real cause is unrecoverable from logs.
- This PR adds row-level fallback diagnostics so the next recurrence surfaces the actual PG error + offending row instead of the masked cascade.

## What changed
- New helper `_insert_with_row_diagnostics(df, table_name, engine, db_label)` in `gcp_dmv_dow.py`:
  - Fast path: same `to_sql(method='multi', chunksize=200)` as before. Zero overhead on success.
  - Failure path: re-issues each row in an isolated transaction (so pg8000's poisoned-transaction cascade is broken), logs the real PG error + full row contents per failure (capped at 10), then raises `RuntimeError` so CI still fails loudly.
- `push_to_db` and `push_to_db_backtest` now both route through the helper.
- `CHANGELOG.md` v4.8.5 entry.

## What did NOT change
- Happy path behaviour, runtime, output schema — identical.
- Other DMV scripts (`gcp_dmv_levels.py`, `gcp_dmv_candle.py`) use the same brittle pattern but didn't fail on #457. Deferred until needed.

## Test plan
- [x] Local happy path: `python gcp_postgres_sandbox/technical_analysis/gcp_dmv_dow.py` against live dbcp + cp_backtest — succeeds in 1.72 min, both tables written.
- [x] Local failure path (NULL into NOT NULL col on a throwaway table):
  - Before: `pg8000.exceptions.InterfaceError: in failed transaction block` — no useful info
  - After: `pg8000.dbapi.ProgrammingError: ERROR 23502 null value in column "slug" violates not-null constraint` + `row={'id':3,'slug':None,'val':30}` + `RuntimeError` re-raised
- [ ] Watch the next scheduled DMV run (cron 05:00 UTC) — if dow stage is healthy, success path is exercised. The diagnostic path will only re-prove itself on the next transient failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)