### PR TITLE
perf: batched INSERT for remaining unbatched to_sql (v4.8.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to the CryptoPrism-DB project will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.8.7] - 2026-05-14 UTC
+
+### Changed
+- **Audit: added `method='multi', chunksize=200` to remaining unbatched `to_sql` calls** found by a repo-wide grep after v4.8.6:
+  - `gcp_postgres_sandbox/data_ingestion/cmc_listings.py:113` (LISTINGS workflow, daily).
+  - `gcp_postgres_sandbox/data_ingestion/gcp_cc_info.py:189` (LISTINGS workflow, daily).
+  - `gcp_postgres_sandbox/backtesting/gcp_dmv_mom_backtest.py:193` (manual backtest workflow).
+
+### Rationale
+**Why:** v4.8.6 surfaced that `gcp_fear_greed_cmc.py` had been missing the batched-INSERT pattern that v4.8.2 added to every script under `technical_analysis/`. A full `to_sql` audit found three more — all outside `technical_analysis/` (two in `data_ingestion/`, one in `backtesting/`), confirming the v4.8.2 sweep was scoped by directory and missed peer dirs. None affect the DMV cron timing directly, but `cmc_listings.py` and `gcp_cc_info.py` run as the LISTINGS daily prereq for OHLCV → DMV, so faster LISTINGS = earlier start for downstream stages.
+
+**How to apply:** Three one-line edits. Identical pattern across all three. No DDL.
+
+### Impact Analysis
+- Risk: Very low. `method='multi'` + `chunksize=200` is the same pattern in production across all DMV scripts since v4.8.2 and now `gcp_fear_greed_cmc.py` since v4.8.6.
+- Performance: ~1000 rows per insert previously at ~150ms RTT each ≈ 2-3 min per call. After batching: ~5 batches of 200 = ~1 sec. Estimated savings: ~5-8 min wall-clock per day across the LISTINGS workflow (two calls).
+- Scope: confirmed via repo-wide grep that all remaining single-line `to_sql` calls under `gcp_postgres_sandbox/` and `scripts/` either already have `method='multi'` (on a continuation line — verified per-file) or are intentional single-row diagnostic inserts (e.g. `gcp_dmv_dow.py:233` row-by-row fallback).
+
 ## [4.8.6] - 2026-05-14 UTC
 
 ### Changed

--- a/gcp_postgres_sandbox/backtesting/gcp_dmv_mom_backtest.py
+++ b/gcp_postgres_sandbox/backtesting/gcp_dmv_mom_backtest.py
@@ -190,7 +190,8 @@ def push_to_db_backtest(df, table_name, engine):
         with engine.connect() as conn:
             conn.execute(text(f'TRUNCATE TABLE "{table_name}"'))
             conn.commit()
-        df.to_sql(table_name, con=engine, if_exists="append", index=False)
+        df.to_sql(table_name, con=engine, if_exists="append", index=False,
+                  method="multi", chunksize=200)
         logging.info(f"{table_name} rebuilt in backtest database (TRUNCATE+INSERT).")
     except Exception as e:
         logging.error(f"Error pushing data to {table_name}: {e}")

--- a/gcp_postgres_sandbox/data_ingestion/cmc_listings.py
+++ b/gcp_postgres_sandbox/data_ingestion/cmc_listings.py
@@ -110,7 +110,8 @@ def upload_to_db(df: pd.DataFrame, db_url: str, table: str):
     """
     engine = create_engine(db_url)
     with engine.begin() as conn:
-        df.to_sql(table, conn, if_exists="replace", index=False)
+        df.to_sql(table, conn, if_exists="replace", index=False,
+                  method="multi", chunksize=200)
     engine.dispose()
 
 

--- a/gcp_postgres_sandbox/data_ingestion/gcp_cc_info.py
+++ b/gcp_postgres_sandbox/data_ingestion/gcp_cc_info.py
@@ -186,7 +186,8 @@ gcp_engine = create_engine(f'postgresql+pg8000://{DB_USER}:{DB_PASSWORD}@{DB_HOS
 
 
 # Write the DataFrame to a new table in the database
-final_df.to_sql('FE_CC_INFO_URL', con=gcp_engine, if_exists='replace', index=False)
+final_df.to_sql('FE_CC_INFO_URL', con=gcp_engine, if_exists='replace', index=False,
+                method='multi', chunksize=200)
 
 
 gcp_engine.dispose()


### PR DESCRIPTION
## Summary

Repo-wide audit follow-up to v4.8.6. Adds `method='multi', chunksize=200` to three more `to_sql` calls that the v4.8.2 batching sweep missed because they live outside `technical_analysis/`.

| File | Workflow | Impact |
|---|---|---|
| \`cmc_listings.py:113\` | LISTINGS daily | ~1000 rows: ~2-3 min → ~1s |
| \`gcp_cc_info.py:189\` | LISTINGS daily | ~1000 rows: ~2-3 min → ~1s |
| \`gcp_dmv_mom_backtest.py:193\` | manual backtest | same |

No DDL. All three use the identical pattern already in production across every DMV script.

## Audit completeness

Repo-wide \`grep '\.to_sql('\` found 14 call sites. Categorized:
- 3 real bugs (this PR).
- 6 false positives with \`method='multi'\` on a continuation line (verified per-file).
- 2 intentional single-row diagnostic inserts (e.g. \`gcp_dmv_dow.py:233\` row-by-row fallback).
- 3 already batched correctly (v4.8.2 / v4.8.6).

## Test plan

- [x] Pattern identical to v4.8.2 (DMV scripts) and v4.8.6 (fear-greed), both in production.
- [ ] Next LISTINGS run (05:00 UTC) exercises cmc_listings + gcp_cc_info in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)