### PR TITLE
fix(ohlcv): reconnect after fetch + SSL require for RDS; backfill via OHLCV_START_DATE

### DIFF
--- a/.github/workflows/OHLCV.yml
+++ b/.github/workflows/OHLCV.yml
@@ -6,7 +6,12 @@ on:
     workflows: ["LISTINGS"]  # Run DMV only after OHLCV completes
     types:
       - completed
-  workflow_dispatch: {}  # Allow manual execution if needed
+  workflow_dispatch:
+    inputs:
+      start_date:
+        description: 'One-time backfill start date (YYYY-MM-DD). Leave empty for normal daily run (yesterday).'
+        required: false
+        default: ''
 
 
 jobs:
@@ -16,13 +21,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      
+
       # Set up R
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
           install-r: true
-          
+
       # Install R packages
       - name: Install R packages
         run: |
@@ -41,12 +46,15 @@ jobs:
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
           DB_PORT: ${{ secrets.DB_PORT }}
           DB_URL: ${{ secrets.DB_URL }}
-          
+
           # API Keys
           CMC_API_KEY: ${{ secrets.CMC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          
+
           # Telegram configuration
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+
+          # One-time historical backfill window (empty = normal daily run / yesterday)
+          OHLCV_START_DATE: ${{ github.event.inputs.start_date }}
         run: Rscript gcp_postgres_sandbox/data_ingestion/gcp_108k_1kcoins.R

--- a/gcp_postgres_sandbox/data_ingestion/gcp_108k_1kcoins.R
+++ b/gcp_postgres_sandbox/data_ingestion/gcp_108k_1kcoins.R
@@ -47,24 +47,29 @@ if (length(missing_vars) > 0) {
 
 print(paste("✅ Database Configuration Loaded: DB_HOST =", CONFIG$db_host, "DB_PORT =", CONFIG$db_port))
 
-# Establish database connections
-con <- dbConnect(
-  RPostgres::Postgres(),
-  host = CONFIG$db_host,
-  dbname = CONFIG$db_name,
-  user = CONFIG$db_user,
-  password = CONFIG$db_password,
-  port = CONFIG$db_port
-)
+# Helper: open a fresh DB connection.
+# sslmode=require is mandatory for AWS RDS; keepalives stop the connection from
+# being reaped during the multi-minute CMC history fetch (the cause of the
+# "SSL error: unexpected eof while reading" failures on writes after migration).
+connect_db <- function(dbname) {
+  dbConnect(
+    RPostgres::Postgres(),
+    host = CONFIG$db_host,
+    dbname = dbname,
+    user = CONFIG$db_user,
+    password = CONFIG$db_password,
+    port = CONFIG$db_port,
+    sslmode = "require",
+    keepalives = 1,
+    keepalives_idle = 30,
+    keepalives_interval = 10,
+    keepalives_count = 5
+  )
+}
 
-con_bt <- dbConnect(
-  RPostgres::Postgres(),
-  host = CONFIG$db_host,
-  dbname = CONFIG$db_name_bt,
-  user = CONFIG$db_user,
-  password = CONFIG$db_password,
-  port = CONFIG$db_port
-)
+# Establish database connections
+con <- connect_db(CONFIG$db_name)
+con_bt <- connect_db(CONFIG$db_name_bt)
 
 # Check if the connection is valid
 if (dbIsValid(con)) {
@@ -108,7 +113,9 @@ all_coins <- crypto_history(
   coin_list = crypto.listings.latest,
   convert = "USD",
   limit = 2000,
-  start_date = Sys.Date()-1,
+  # OHLCV_START_DATE lets us run a one-time historical backfill (e.g. fill a gap
+  # after migration) without code changes. Defaults to yesterday for daily runs.
+  start_date = as.Date(Sys.getenv("OHLCV_START_DATE", as.character(Sys.Date()-1))),
   end_date = Sys.Date()+1,
   sleep = 0
 )
@@ -135,6 +142,15 @@ crypto_global_quote <- crypto_global_quotes(
 
 # Write dataframes to database
 print("Writing data to database...")
+
+# The CMC history fetch above can run for several minutes; AWS RDS may have
+# reaped the idle connections opened before the fetch. Reconnect fresh before
+# any writes to avoid "SSL error: unexpected eof while reading".
+print("Reconnecting to database after fetch (avoid stale/idle connection)...")
+try(dbDisconnect(con), silent = TRUE)
+try(dbDisconnect(con_bt), silent = TRUE)
+con <- connect_db(CONFIG$db_name)
+con_bt <- connect_db(CONFIG$db_name_bt)
 
 # Write global quotes
 dbWriteTable(con, "crypto_global_latest", crypto_global_quote, overwrite = TRUE, row.names = FALSE)


### PR DESCRIPTION
## Problem
After the GCP→AWS RDS migration, the OHLCV job (`gcp_108k_1kcoins.R`) fails on write:
```
[1] "Fetched OHLCV data for 985 records"
[1] "Writing data to database..."
Error: Failed to prepare query : SSL error: unexpected eof while reading
```
The fetch (CMC) succeeds; only the DB **write** fails. Root cause: the DB connections are opened **before** the multi-minute per-coin `crypto_history()` fetch, sit idle the whole time, and RDS reaps them. The first write after the fetch hits a dead/SSL-EOF connection. The script also passed no `sslmode`.

## Fix
- **Reconnect fresh right before writing** (after the fetch) — the actual fix for the idle-reap.
- Add `sslmode=require` + keepalives via a `connect_db()` helper (RDS requires SSL).
- **`OHLCV_START_DATE` env** to run a one-time historical backfill without code changes (default = yesterday, so daily runs are unchanged). Exposed as a `start_date` `workflow_dispatch` input on OHLCV.yml.

## Why a backfill is needed
RDS holds only the migration snapshot (data stops ~2026-06-13). The daily window is `Sys.Date()-1`, so normal runs won't fill 2026-06-14→today. After merge, dispatch OHLCV with `start_date=2026-06-13` once to fill the gap. The existing dedup (PK `(slug,timestamp)`) makes the overlap safe — no duplicates.

## Safety
- PK `(slug, timestamp)` confirmed on both `1K_coins_ohlcv` and `108_1K_coins_ohlcv`; 0 current dupes.
- Dedup excludes existing keys before `append=TRUE`, so the wide window only inserts missing rows.
- Daily behavior unchanged when `OHLCV_START_DATE` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)